### PR TITLE
:bug: don't show Tx notification twice.

### DIFF
--- a/lib/application/check_transaction_worker/provider.dart
+++ b/lib/application/check_transaction_worker/provider.dart
@@ -13,7 +13,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 part 'state.dart';
 
 abstract class CheckTransactionsProvider {
-  static final provider = StreamProvider<ReceivedTransaction>(
+  static final provider = StreamProvider.autoDispose<ReceivedTransaction>(
     _checkTransactions,
   );
 }


### PR DESCRIPTION
CheckTransactionsProvider re-created when leaving Home page.

That way, stream is not polluted by previous events.