### PR TITLE
:sparkles: rework faucet behavior

### DIFF
--- a/lib/application/faucet/provider.dart
+++ b/lib/application/faucet/provider.dart
@@ -80,8 +80,6 @@ class _FaucetCooldownNotifier extends AsyncNotifier<Duration> {
   Future<void> startCooldown({
     required DateTime endDate,
   }) async {
-    if (state.isLoading || state.valueOrNull != Duration.zero) return;
-
     final repository = ref.watch(_faucetRepositoryProvider);
     await repository.setClaimCooldownEndDate(date: endDate);
 

--- a/lib/application/faucet/provider.g.dart
+++ b/lib/application/faucet/provider.g.dart
@@ -52,7 +52,7 @@ final _isDeviceCompatibleProvider = FutureProvider<bool>(
       : $_isDeviceCompatibleHash,
 );
 typedef _IsDeviceCompatibleRef = FutureProviderRef<bool>;
-String $_isFaucetEnabledHash() => r'd8203c75a1aa708300444c7c3b660b29a82f95a5';
+String $_isFaucetEnabledHash() => r'828846b82c9029b973cb4bda1dae1c4de1f15be7';
 
 /// See also [_isFaucetEnabled].
 final _isFaucetEnabledProvider = FutureProvider<bool>(

--- a/lib/domain/models/core/failures.dart
+++ b/lib/domain/models/core/failures.dart
@@ -7,7 +7,9 @@ class Failure with _$Failure implements Exception {
   const Failure._();
   const factory Failure.loggedOut() = _LoggedOut;
   const factory Failure.network() = _NetworkFailure;
-  const factory Failure.quotaExceeded() = _QuotaExceededFailure;
+  const factory Failure.quotaExceeded({
+    DateTime? cooldownEndDate,
+  }) = _QuotaExceededFailure;
   const factory Failure.insufficientFunds() = _InsuffientFunds;
   const factory Failure.invalidValue() = _InvalidValue;
   const factory Failure.other({

--- a/lib/domain/models/core/failures.freezed.dart
+++ b/lib/domain/models/core/failures.freezed.dart
@@ -20,7 +20,7 @@ mixin _$Failure {
   TResult when<TResult extends Object?>({
     required TResult Function() loggedOut,
     required TResult Function() network,
-    required TResult Function() quotaExceeded,
+    required TResult Function(DateTime? cooldownEndDate) quotaExceeded,
     required TResult Function() insufficientFunds,
     required TResult Function() invalidValue,
     required TResult Function(Object? cause, StackTrace? stack) other,
@@ -30,7 +30,7 @@ mixin _$Failure {
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function()? loggedOut,
     TResult? Function()? network,
-    TResult? Function()? quotaExceeded,
+    TResult? Function(DateTime? cooldownEndDate)? quotaExceeded,
     TResult? Function()? insufficientFunds,
     TResult? Function()? invalidValue,
     TResult? Function(Object? cause, StackTrace? stack)? other,
@@ -40,7 +40,7 @@ mixin _$Failure {
   TResult maybeWhen<TResult extends Object?>({
     TResult Function()? loggedOut,
     TResult Function()? network,
-    TResult Function()? quotaExceeded,
+    TResult Function(DateTime? cooldownEndDate)? quotaExceeded,
     TResult Function()? insufficientFunds,
     TResult Function()? invalidValue,
     TResult Function(Object? cause, StackTrace? stack)? other,
@@ -137,7 +137,7 @@ class _$_LoggedOut extends _LoggedOut {
   TResult when<TResult extends Object?>({
     required TResult Function() loggedOut,
     required TResult Function() network,
-    required TResult Function() quotaExceeded,
+    required TResult Function(DateTime? cooldownEndDate) quotaExceeded,
     required TResult Function() insufficientFunds,
     required TResult Function() invalidValue,
     required TResult Function(Object? cause, StackTrace? stack) other,
@@ -150,7 +150,7 @@ class _$_LoggedOut extends _LoggedOut {
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function()? loggedOut,
     TResult? Function()? network,
-    TResult? Function()? quotaExceeded,
+    TResult? Function(DateTime? cooldownEndDate)? quotaExceeded,
     TResult? Function()? insufficientFunds,
     TResult? Function()? invalidValue,
     TResult? Function(Object? cause, StackTrace? stack)? other,
@@ -163,7 +163,7 @@ class _$_LoggedOut extends _LoggedOut {
   TResult maybeWhen<TResult extends Object?>({
     TResult Function()? loggedOut,
     TResult Function()? network,
-    TResult Function()? quotaExceeded,
+    TResult Function(DateTime? cooldownEndDate)? quotaExceeded,
     TResult Function()? insufficientFunds,
     TResult Function()? invalidValue,
     TResult Function(Object? cause, StackTrace? stack)? other,
@@ -264,7 +264,7 @@ class _$_NetworkFailure extends _NetworkFailure {
   TResult when<TResult extends Object?>({
     required TResult Function() loggedOut,
     required TResult Function() network,
-    required TResult Function() quotaExceeded,
+    required TResult Function(DateTime? cooldownEndDate) quotaExceeded,
     required TResult Function() insufficientFunds,
     required TResult Function() invalidValue,
     required TResult Function(Object? cause, StackTrace? stack) other,
@@ -277,7 +277,7 @@ class _$_NetworkFailure extends _NetworkFailure {
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function()? loggedOut,
     TResult? Function()? network,
-    TResult? Function()? quotaExceeded,
+    TResult? Function(DateTime? cooldownEndDate)? quotaExceeded,
     TResult? Function()? insufficientFunds,
     TResult? Function()? invalidValue,
     TResult? Function(Object? cause, StackTrace? stack)? other,
@@ -290,7 +290,7 @@ class _$_NetworkFailure extends _NetworkFailure {
   TResult maybeWhen<TResult extends Object?>({
     TResult Function()? loggedOut,
     TResult Function()? network,
-    TResult Function()? quotaExceeded,
+    TResult Function(DateTime? cooldownEndDate)? quotaExceeded,
     TResult Function()? insufficientFunds,
     TResult Function()? invalidValue,
     TResult Function(Object? cause, StackTrace? stack)? other,
@@ -356,6 +356,8 @@ abstract class _$$_QuotaExceededFailureCopyWith<$Res> {
   factory _$$_QuotaExceededFailureCopyWith(_$_QuotaExceededFailure value,
           $Res Function(_$_QuotaExceededFailure) then) =
       __$$_QuotaExceededFailureCopyWithImpl<$Res>;
+  @useResult
+  $Res call({DateTime? cooldownEndDate});
 }
 
 /// @nodoc
@@ -365,38 +367,64 @@ class __$$_QuotaExceededFailureCopyWithImpl<$Res>
   __$$_QuotaExceededFailureCopyWithImpl(_$_QuotaExceededFailure _value,
       $Res Function(_$_QuotaExceededFailure) _then)
       : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? cooldownEndDate = freezed,
+  }) {
+    return _then(_$_QuotaExceededFailure(
+      cooldownEndDate: freezed == cooldownEndDate
+          ? _value.cooldownEndDate
+          : cooldownEndDate // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+    ));
+  }
 }
 
 /// @nodoc
 
 class _$_QuotaExceededFailure extends _QuotaExceededFailure {
-  const _$_QuotaExceededFailure() : super._();
+  const _$_QuotaExceededFailure({this.cooldownEndDate}) : super._();
+
+  @override
+  final DateTime? cooldownEndDate;
 
   @override
   String toString() {
-    return 'Failure.quotaExceeded()';
+    return 'Failure.quotaExceeded(cooldownEndDate: $cooldownEndDate)';
   }
 
   @override
   bool operator ==(dynamic other) {
     return identical(this, other) ||
-        (other.runtimeType == runtimeType && other is _$_QuotaExceededFailure);
+        (other.runtimeType == runtimeType &&
+            other is _$_QuotaExceededFailure &&
+            (identical(other.cooldownEndDate, cooldownEndDate) ||
+                other.cooldownEndDate == cooldownEndDate));
   }
 
   @override
-  int get hashCode => runtimeType.hashCode;
+  int get hashCode => Object.hash(runtimeType, cooldownEndDate);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_QuotaExceededFailureCopyWith<_$_QuotaExceededFailure> get copyWith =>
+      __$$_QuotaExceededFailureCopyWithImpl<_$_QuotaExceededFailure>(
+          this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function() loggedOut,
     required TResult Function() network,
-    required TResult Function() quotaExceeded,
+    required TResult Function(DateTime? cooldownEndDate) quotaExceeded,
     required TResult Function() insufficientFunds,
     required TResult Function() invalidValue,
     required TResult Function(Object? cause, StackTrace? stack) other,
   }) {
-    return quotaExceeded();
+    return quotaExceeded(cooldownEndDate);
   }
 
   @override
@@ -404,12 +432,12 @@ class _$_QuotaExceededFailure extends _QuotaExceededFailure {
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function()? loggedOut,
     TResult? Function()? network,
-    TResult? Function()? quotaExceeded,
+    TResult? Function(DateTime? cooldownEndDate)? quotaExceeded,
     TResult? Function()? insufficientFunds,
     TResult? Function()? invalidValue,
     TResult? Function(Object? cause, StackTrace? stack)? other,
   }) {
-    return quotaExceeded?.call();
+    return quotaExceeded?.call(cooldownEndDate);
   }
 
   @override
@@ -417,14 +445,14 @@ class _$_QuotaExceededFailure extends _QuotaExceededFailure {
   TResult maybeWhen<TResult extends Object?>({
     TResult Function()? loggedOut,
     TResult Function()? network,
-    TResult Function()? quotaExceeded,
+    TResult Function(DateTime? cooldownEndDate)? quotaExceeded,
     TResult Function()? insufficientFunds,
     TResult Function()? invalidValue,
     TResult Function(Object? cause, StackTrace? stack)? other,
     required TResult orElse(),
   }) {
     if (quotaExceeded != null) {
-      return quotaExceeded();
+      return quotaExceeded(cooldownEndDate);
     }
     return orElse();
   }
@@ -474,8 +502,14 @@ class _$_QuotaExceededFailure extends _QuotaExceededFailure {
 }
 
 abstract class _QuotaExceededFailure extends Failure {
-  const factory _QuotaExceededFailure() = _$_QuotaExceededFailure;
+  const factory _QuotaExceededFailure({final DateTime? cooldownEndDate}) =
+      _$_QuotaExceededFailure;
   const _QuotaExceededFailure._() : super._();
+
+  DateTime? get cooldownEndDate;
+  @JsonKey(ignore: true)
+  _$$_QuotaExceededFailureCopyWith<_$_QuotaExceededFailure> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
@@ -518,7 +552,7 @@ class _$_InsuffientFunds extends _InsuffientFunds {
   TResult when<TResult extends Object?>({
     required TResult Function() loggedOut,
     required TResult Function() network,
-    required TResult Function() quotaExceeded,
+    required TResult Function(DateTime? cooldownEndDate) quotaExceeded,
     required TResult Function() insufficientFunds,
     required TResult Function() invalidValue,
     required TResult Function(Object? cause, StackTrace? stack) other,
@@ -531,7 +565,7 @@ class _$_InsuffientFunds extends _InsuffientFunds {
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function()? loggedOut,
     TResult? Function()? network,
-    TResult? Function()? quotaExceeded,
+    TResult? Function(DateTime? cooldownEndDate)? quotaExceeded,
     TResult? Function()? insufficientFunds,
     TResult? Function()? invalidValue,
     TResult? Function(Object? cause, StackTrace? stack)? other,
@@ -544,7 +578,7 @@ class _$_InsuffientFunds extends _InsuffientFunds {
   TResult maybeWhen<TResult extends Object?>({
     TResult Function()? loggedOut,
     TResult Function()? network,
-    TResult Function()? quotaExceeded,
+    TResult Function(DateTime? cooldownEndDate)? quotaExceeded,
     TResult Function()? insufficientFunds,
     TResult Function()? invalidValue,
     TResult Function(Object? cause, StackTrace? stack)? other,
@@ -645,7 +679,7 @@ class _$_InvalidValue extends _InvalidValue {
   TResult when<TResult extends Object?>({
     required TResult Function() loggedOut,
     required TResult Function() network,
-    required TResult Function() quotaExceeded,
+    required TResult Function(DateTime? cooldownEndDate) quotaExceeded,
     required TResult Function() insufficientFunds,
     required TResult Function() invalidValue,
     required TResult Function(Object? cause, StackTrace? stack) other,
@@ -658,7 +692,7 @@ class _$_InvalidValue extends _InvalidValue {
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function()? loggedOut,
     TResult? Function()? network,
-    TResult? Function()? quotaExceeded,
+    TResult? Function(DateTime? cooldownEndDate)? quotaExceeded,
     TResult? Function()? insufficientFunds,
     TResult? Function()? invalidValue,
     TResult? Function(Object? cause, StackTrace? stack)? other,
@@ -671,7 +705,7 @@ class _$_InvalidValue extends _InvalidValue {
   TResult maybeWhen<TResult extends Object?>({
     TResult Function()? loggedOut,
     TResult Function()? network,
-    TResult Function()? quotaExceeded,
+    TResult Function(DateTime? cooldownEndDate)? quotaExceeded,
     TResult Function()? insufficientFunds,
     TResult Function()? invalidValue,
     TResult Function(Object? cause, StackTrace? stack)? other,
@@ -804,7 +838,7 @@ class _$_OtherFailure extends _OtherFailure {
   TResult when<TResult extends Object?>({
     required TResult Function() loggedOut,
     required TResult Function() network,
-    required TResult Function() quotaExceeded,
+    required TResult Function(DateTime? cooldownEndDate) quotaExceeded,
     required TResult Function() insufficientFunds,
     required TResult Function() invalidValue,
     required TResult Function(Object? cause, StackTrace? stack) other,
@@ -817,7 +851,7 @@ class _$_OtherFailure extends _OtherFailure {
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function()? loggedOut,
     TResult? Function()? network,
-    TResult? Function()? quotaExceeded,
+    TResult? Function(DateTime? cooldownEndDate)? quotaExceeded,
     TResult? Function()? insufficientFunds,
     TResult? Function()? invalidValue,
     TResult? Function(Object? cause, StackTrace? stack)? other,
@@ -830,7 +864,7 @@ class _$_OtherFailure extends _OtherFailure {
   TResult maybeWhen<TResult extends Object?>({
     TResult Function()? loggedOut,
     TResult Function()? network,
-    TResult Function()? quotaExceeded,
+    TResult Function(DateTime? cooldownEndDate)? quotaExceeded,
     TResult Function()? insufficientFunds,
     TResult Function()? invalidValue,
     TResult Function(Object? cause, StackTrace? stack)? other,

--- a/lib/domain/repositories/faucet.dart
+++ b/lib/domain/repositories/faucet.dart
@@ -5,22 +5,24 @@ abstract class FaucetRepositoryInterface {
   /// Return [null] if device is not authorized to request Faucet
   /// Else, returns the challenge.
   Future<Result<String, Failure>> requestChallenge({
+    required String keychainAddress,
     required String deviceId,
   });
 
   /// Claims reward
-  Future<Result<void, Failure>> claim({
+  Future<Result<DateTime, Failure>> claim({
     required String challenge,
     required String deviceId,
+    required String recipientAddress,
     required String keychainAddress,
   });
 
-  Future<DateTime?> getLastClaimDate();
+  Future<DateTime?> getClaimCooldownEndDate();
 
-  Future<void> setLastClaimDate();
+  Future<void> setClaimCooldownEndDate({required DateTime date});
 
   /// Clears all stored data
   Future<void> clear();
 
-  Future<bool> isFaucetEnabled();
+  Future<Result<bool, Failure>> isFaucetEnabled();
 }

--- a/lib/infrastructure/datasources/hive_preferences.dart
+++ b/lib/infrastructure/datasources/hive_preferences.dart
@@ -256,11 +256,13 @@ class HivePreferencesDatasource {
   }
 
   DateTime? getFaucetClaimCooldownEndDate() {
-    return _getValue(faucetClaimCooldownEndDate, defaultValue: null);
+    return DateTime.tryParse(
+      _getValue(faucetClaimCooldownEndDate, defaultValue: ''),
+    );
   }
 
   Future<void> setFaucetClaimCooldownEndDate(DateTime date) {
-    return _setValue(faucetClaimCooldownEndDate, date);
+    return _setValue(faucetClaimCooldownEndDate, date.toIso8601String());
   }
 
   Future<void> clearFaucetClaimCooldownEndDate() {

--- a/lib/infrastructure/datasources/hive_preferences.dart
+++ b/lib/infrastructure/datasources/hive_preferences.dart
@@ -30,7 +30,8 @@ class HivePreferencesDatasource {
   static const String lock = 'archethic_wallet_lock';
   static const String lockTimeout = 'archethic_wallet_lock_timeout';
   static const String autoLockDate = 'archethic_wallet_autolock_date';
-  static const String faucetClaimDate = 'archethic_wallet_faucet_date';
+  static const String faucetClaimCooldownEndDate =
+      'archethic_wallet_faucet_claim_cooldown_end_date';
   static const String hasShownRootWarning =
       'archethic_wallet_has_shown_root_warning';
   static const String pinAttempts = 'archethic_wallet_pin_attempts';
@@ -254,15 +255,15 @@ class HivePreferencesDatasource {
     await _removeValue(autoLockDate);
   }
 
-  DateTime? getLastFaucetClaimDate() {
-    return _getValue(faucetClaimDate, defaultValue: null);
+  DateTime? getFaucetClaimCooldownEndDate() {
+    return _getValue(faucetClaimCooldownEndDate, defaultValue: null);
   }
 
-  Future<void> setLastFaucetClaimDate(DateTime date) async {
-    return _setValue(faucetClaimDate, date);
+  Future<void> setFaucetClaimCooldownEndDate(DateTime date) {
+    return _setValue(faucetClaimCooldownEndDate, date);
   }
 
-  Future<void> clearLastFaucetClaimDate() async {
-    return _removeValue(faucetClaimDate);
+  Future<void> clearFaucetClaimCooldownEndDate() {
+    return _removeValue(faucetClaimCooldownEndDate);
   }
 }

--- a/lib/infrastructure/repositories/faucet.dart
+++ b/lib/infrastructure/repositories/faucet.dart
@@ -27,7 +27,7 @@ class FaucetLimitReachedDTO {
 }
 
 class _FaucetRoutes {
-  String get uriRoot => 'http://192.168.1.15:3000';
+  String get uriRoot => 'https://airdrop.archethic.net';
   String get status => '$uriRoot/status';
   String get challenge => '$uriRoot/challenge';
   String get claim => '$uriRoot/claim';

--- a/lib/infrastructure/repositories/faucet.dart
+++ b/lib/infrastructure/repositories/faucet.dart
@@ -19,6 +19,7 @@ class FaucetLimitReachedDTO {
       FaucetLimitReachedDTO(
         unlockTime: DateTime.fromMillisecondsSinceEpoch(
           json['unlockTime'] * 1000,
+          isUtc: true,
         ),
       );
 

--- a/lib/infrastructure/repositories/faucet.dart
+++ b/lib/infrastructure/repositories/faucet.dart
@@ -26,7 +26,7 @@ class FaucetLimitReachedDTO {
 }
 
 class _FaucetRoutes {
-  String get uriRoot => 'http://192.168.1.20:3000';
+  String get uriRoot => 'http://192.168.1.15:3000';
   String get status => '$uriRoot/status';
   String get challenge => '$uriRoot/challenge';
   String get claim => '$uriRoot/claim';
@@ -129,10 +129,11 @@ class FaucetRepository implements FaucetRepositoryInterface {
           throw const Failure.other();
         }
 
-        final cooldownEndDate = DateTime.fromMillisecondsSinceEpoch(
-          json.decode(response.body)['cooldownEndDate'],
+        final unlockTime = DateTime.fromMillisecondsSinceEpoch(
+          json.decode(response.body)['unlockTime'] * 1000,
+          isUtc: true,
         );
-        return cooldownEndDate;
+        return unlockTime;
       });
 
   @override

--- a/lib/ui/views/main/components/faucet.dart
+++ b/lib/ui/views/main/components/faucet.dart
@@ -188,7 +188,9 @@ class _CooldownCounter extends ConsumerWidget {
           )
           .replaceAll(
             '%2',
-            (cooldownRemainingTime.inMinutes % 60).toString().padLeft(2, '0'),
+            ((cooldownRemainingTime.inMinutes % 60) + 1)
+                .toString()
+                .padLeft(2, '0'),
           ),
       style: theme.textStyleSize12W100Primary,
     );

--- a/lib/ui/views/main/components/faucet.dart
+++ b/lib/ui/views/main/components/faucet.dart
@@ -18,10 +18,6 @@ part 'faucet.g.dart';
 /// True if the Faucet claim button should be active
 @Riverpod(keepAlive: true)
 bool _isFaucetRequestButtonActive(Ref ref) {
-  final isCooldownActive = ref.watch(FaucetProviders.claimCooldown).maybeWhen(
-        data: (data) => data > Duration.zero,
-        orElse: () => true,
-      );
   final isFaucetEnabled = ref.watch(FaucetProviders.isFaucetEnabled).maybeWhen(
         data: id,
         orElse: () => false,
@@ -30,7 +26,7 @@ bool _isFaucetRequestButtonActive(Ref ref) {
   final isFaucetClaimRequestRunning =
       ref.watch(FaucetProviders.claimRequest).isLoading;
 
-  return !isCooldownActive && isFaucetEnabled && !isFaucetClaimRequestRunning;
+  return isFaucetEnabled && !isFaucetClaimRequestRunning;
 }
 
 class FaucetBanner extends ConsumerWidget {

--- a/lib/ui/views/main/components/faucet.g.dart
+++ b/lib/ui/views/main/components/faucet.g.dart
@@ -30,7 +30,7 @@ class _SystemHash {
 }
 
 String $_isFaucetRequestButtonActiveHash() =>
-    r'5e523e6d6e97b12d3f2f2c3cdfbdeeab25917055';
+    r'95430dc2f8679f214ea8cfeedfac8d3af9e6fb80';
 
 /// True if the Faucet claim button should be active
 ///


### PR DESCRIPTION
- discriminate DDos from faucet alredy claimed
- faucet button still active when faucet claimed.
- cooldown end date managed by backend.