### PR TITLE
507-Refacto Code for NetworkDialog And add check on Url

### DIFF
--- a/lib/application/network/provider.dart
+++ b/lib/application/network/provider.dart
@@ -6,16 +6,30 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 part 'provider.g.dart';
 
 @riverpod
-Future<List<Node>> _networkNodes(
-  _NetworkNodesRef ref, {
+String _networkLink(
+  _NetworkLinkRef ref, {
   required AvailableNetworks network,
-}) async {
+}) {
   final networkSetting = NetworksSetting(
     network: network,
     networkDevEndpoint: '',
   );
 
   final link = networkSetting.getLink();
+
+  return link;
+}
+
+@riverpod
+Future<List<Node>> _networkNodes(
+  _NetworkNodesRef ref, {
+  required AvailableNetworks network,
+}) async {
+  final link = ref.read(
+    _networkLinkProvider(
+      network: network,
+    ),
+  );
 
   final nodeListMain = await ApiService(
     link,
@@ -29,6 +43,11 @@ Future<bool> _isReservedNodeUri(
   _IsReservedNodeUriRef ref, {
   required Uri uri,
 }) async {
+  // Check if default uri is used
+  if (DefaultNetworksHost.archethicMainNetHost.value == uri.host) return true;
+  if (DefaultNetworksHost.archethicTestNetHost.value == uri.host) return true;
+
+  // Check if reserved node of network is used
   final nodeListMain = await ref.watch(
     _networkNodesProvider(
       network: AvailableNetworks.archethicMainNet,
@@ -46,6 +65,7 @@ Future<bool> _isReservedNodeUri(
 }
 
 abstract class NetworkProvider {
+  static final networkLink = _networkLinkProvider;
   static final networkNodes = _networkNodesProvider;
   static final isReservedNodeUri = _isReservedNodeUriProvider;
 }

--- a/lib/application/network/provider.dart
+++ b/lib/application/network/provider.dart
@@ -1,0 +1,51 @@
+/// SPDX-License-Identifier: AGPL-3.0-or-later
+import 'package:aewallet/model/available_networks.dart';
+import 'package:archethic_lib_dart/archethic_lib_dart.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'provider.g.dart';
+
+@riverpod
+Future<List<Node>> _networkNodes(
+  _NetworkNodesRef ref, {
+  required AvailableNetworks network,
+}) async {
+  final networkSetting = NetworksSetting(
+    network: network,
+    networkDevEndpoint: '',
+  );
+
+  final link = networkSetting.getLink();
+
+  final nodeListMain = await ApiService(
+    link,
+  ).getNodeList();
+
+  return nodeListMain;
+}
+
+@riverpod
+Future<bool> _isReservedNodeUri(
+  _IsReservedNodeUriRef ref, {
+  required Uri uri,
+}) async {
+  final nodeListMain = await ref.watch(
+    _networkNodesProvider(
+      network: AvailableNetworks.archethicMainNet,
+    ).future,
+  );
+  final nodeListTest = await ref.watch(
+    _networkNodesProvider(
+      network: AvailableNetworks.archethicTestNet,
+    ).future,
+  );
+
+  return nodeListMain.followedBy(nodeListTest).any(
+        (node) => node.ip == uri.host && node.port == uri.port,
+      );
+}
+
+abstract class NetworkProvider {
+  static final networkNodes = _networkNodesProvider;
+  static final isReservedNodeUri = _isReservedNodeUriProvider;
+}

--- a/lib/application/network/provider.dart
+++ b/lib/application/network/provider.dart
@@ -47,7 +47,7 @@ Future<bool> _isReservedNodeUri(
   if (DefaultNetworksHost.archethicMainNetHost.value == uri.host) return true;
   if (DefaultNetworksHost.archethicTestNetHost.value == uri.host) return true;
 
-  // Check if reserved node of network is used
+  // Check if reserved nodes of network is used
   final nodeListMain = await ref.watch(
     _networkNodesProvider(
       network: AvailableNetworks.archethicMainNet,

--- a/lib/application/network/provider.g.dart
+++ b/lib/application/network/provider.g.dart
@@ -29,7 +29,77 @@ class _SystemHash {
   }
 }
 
-String $_networkNodesHash() => r'5b20cd42d0d005bab5f70c9ee0462de6cc927596';
+String $_networkLinkHash() => r'a1ad177b35a24e339a2202520047ef4199644dc4';
+
+/// See also [_networkLink].
+class _NetworkLinkProvider extends AutoDisposeProvider<String> {
+  _NetworkLinkProvider({
+    required this.network,
+  }) : super(
+          (ref) => _networkLink(
+            ref,
+            network: network,
+          ),
+          from: _networkLinkProvider,
+          name: r'_networkLinkProvider',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : $_networkLinkHash,
+        );
+
+  final AvailableNetworks network;
+
+  @override
+  bool operator ==(Object other) {
+    return other is _NetworkLinkProvider && other.network == network;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, network.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+typedef _NetworkLinkRef = AutoDisposeProviderRef<String>;
+
+/// See also [_networkLink].
+final _networkLinkProvider = _NetworkLinkFamily();
+
+class _NetworkLinkFamily extends Family<String> {
+  _NetworkLinkFamily();
+
+  _NetworkLinkProvider call({
+    required AvailableNetworks network,
+  }) {
+    return _NetworkLinkProvider(
+      network: network,
+    );
+  }
+
+  @override
+  AutoDisposeProvider<String> getProviderOverride(
+    covariant _NetworkLinkProvider provider,
+  ) {
+    return call(
+      network: provider.network,
+    );
+  }
+
+  @override
+  List<ProviderOrFamily>? get allTransitiveDependencies => null;
+
+  @override
+  List<ProviderOrFamily>? get dependencies => null;
+
+  @override
+  String? get name => r'_networkLinkProvider';
+}
+
+String $_networkNodesHash() => r'9e80abce0e872f3536ca1c81cd6d2710eda2ba87';
 
 /// See also [_networkNodes].
 class _NetworkNodesProvider extends AutoDisposeFutureProvider<List<Node>> {
@@ -99,7 +169,7 @@ class _NetworkNodesFamily extends Family<AsyncValue<List<Node>>> {
   String? get name => r'_networkNodesProvider';
 }
 
-String $_isReservedNodeUriHash() => r'6abbdddb9412c19197e1f1a11290f2d9e328d08c';
+String $_isReservedNodeUriHash() => r'3f71b1eaa866dad51e8263b46aad7d6f4737a451';
 
 /// See also [_isReservedNodeUri].
 class _IsReservedNodeUriProvider extends AutoDisposeFutureProvider<bool> {

--- a/lib/application/network/provider.g.dart
+++ b/lib/application/network/provider.g.dart
@@ -169,7 +169,7 @@ class _NetworkNodesFamily extends Family<AsyncValue<List<Node>>> {
   String? get name => r'_networkNodesProvider';
 }
 
-String $_isReservedNodeUriHash() => r'3f71b1eaa866dad51e8263b46aad7d6f4737a451';
+String $_isReservedNodeUriHash() => r'60dab84965fa35027911aaa0cabff6c5523183b5';
 
 /// See also [_isReservedNodeUri].
 class _IsReservedNodeUriProvider extends AutoDisposeFutureProvider<bool> {

--- a/lib/application/network/provider.g.dart
+++ b/lib/application/network/provider.g.dart
@@ -1,0 +1,170 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// ignore_for_file: avoid_private_typedef_functions, non_constant_identifier_names, subtype_of_sealed_class, invalid_use_of_internal_member, unused_element, constant_identifier_names, unnecessary_raw_strings, library_private_types_in_public_api
+
+/// Copied from Dart SDK
+class _SystemHash {
+  _SystemHash._();
+
+  static int combine(int hash, int value) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + value);
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
+    return hash ^ (hash >> 6);
+  }
+
+  static int finish(int hash) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
+    // ignore: parameter_assignments
+    hash = hash ^ (hash >> 11);
+    return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
+  }
+}
+
+String $_networkNodesHash() => r'5b20cd42d0d005bab5f70c9ee0462de6cc927596';
+
+/// See also [_networkNodes].
+class _NetworkNodesProvider extends AutoDisposeFutureProvider<List<Node>> {
+  _NetworkNodesProvider({
+    required this.network,
+  }) : super(
+          (ref) => _networkNodes(
+            ref,
+            network: network,
+          ),
+          from: _networkNodesProvider,
+          name: r'_networkNodesProvider',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : $_networkNodesHash,
+        );
+
+  final AvailableNetworks network;
+
+  @override
+  bool operator ==(Object other) {
+    return other is _NetworkNodesProvider && other.network == network;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, network.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+typedef _NetworkNodesRef = AutoDisposeFutureProviderRef<List<Node>>;
+
+/// See also [_networkNodes].
+final _networkNodesProvider = _NetworkNodesFamily();
+
+class _NetworkNodesFamily extends Family<AsyncValue<List<Node>>> {
+  _NetworkNodesFamily();
+
+  _NetworkNodesProvider call({
+    required AvailableNetworks network,
+  }) {
+    return _NetworkNodesProvider(
+      network: network,
+    );
+  }
+
+  @override
+  AutoDisposeFutureProvider<List<Node>> getProviderOverride(
+    covariant _NetworkNodesProvider provider,
+  ) {
+    return call(
+      network: provider.network,
+    );
+  }
+
+  @override
+  List<ProviderOrFamily>? get allTransitiveDependencies => null;
+
+  @override
+  List<ProviderOrFamily>? get dependencies => null;
+
+  @override
+  String? get name => r'_networkNodesProvider';
+}
+
+String $_isReservedNodeUriHash() => r'6abbdddb9412c19197e1f1a11290f2d9e328d08c';
+
+/// See also [_isReservedNodeUri].
+class _IsReservedNodeUriProvider extends AutoDisposeFutureProvider<bool> {
+  _IsReservedNodeUriProvider({
+    required this.uri,
+  }) : super(
+          (ref) => _isReservedNodeUri(
+            ref,
+            uri: uri,
+          ),
+          from: _isReservedNodeUriProvider,
+          name: r'_isReservedNodeUriProvider',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : $_isReservedNodeUriHash,
+        );
+
+  final Uri uri;
+
+  @override
+  bool operator ==(Object other) {
+    return other is _IsReservedNodeUriProvider && other.uri == uri;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, uri.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+typedef _IsReservedNodeUriRef = AutoDisposeFutureProviderRef<bool>;
+
+/// See also [_isReservedNodeUri].
+final _isReservedNodeUriProvider = _IsReservedNodeUriFamily();
+
+class _IsReservedNodeUriFamily extends Family<AsyncValue<bool>> {
+  _IsReservedNodeUriFamily();
+
+  _IsReservedNodeUriProvider call({
+    required Uri uri,
+  }) {
+    return _IsReservedNodeUriProvider(
+      uri: uri,
+    );
+  }
+
+  @override
+  AutoDisposeFutureProvider<bool> getProviderOverride(
+    covariant _IsReservedNodeUriProvider provider,
+  ) {
+    return call(
+      uri: provider.uri,
+    );
+  }
+
+  @override
+  List<ProviderOrFamily>? get allTransitiveDependencies => null;
+
+  @override
+  List<ProviderOrFamily>? get dependencies => null;
+
+  @override
+  String? get name => r'_isReservedNodeUriProvider';
+}

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1812,6 +1812,12 @@
     "placeholders_order": [],
     "placeholders": {}
   },
+  "enterEndpointUseByNetwork": "The endpoint is already used by a network",
+  "@enterEndpointUseByNetwork": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
   "enterEndpointHeader": "Please, specify your endpoint",
   "@enterEndpointHeader": {
     "type": "text",

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -304,6 +304,7 @@
 	"showBlog": "Afficher le blog",
 	"enterEndpointBlank": "Le point d'accès est obligatoire.",
 	"enterEndpointNotValid": "Le point d'accès n'est pas valide.",
+  "enterEndpointUseByNetwork": "Le point d'accès est déjà utilisé par un réseau.",
 	"enterEndpointHeader": "Veuillez préciser votre point d'accès.",
 	"introNewWalletGetFirstInfosWelcome": "Bienvenue dans le Wallet Archethic.",
 	"introNewWalletGetFirstInfosNameRequest": "Quel nom souhaitez-vous donner à ce compte, compte qui sera stocké dans votre porte-clés décentralisé ?",

--- a/lib/l10n/intl_messages.arb
+++ b/lib/l10n/intl_messages.arb
@@ -360,6 +360,12 @@
     "placeholders_order": [],
     "placeholders": {}
   },
+  "enterEndpointUseByNetwork": "The endpoint is already used by a network",
+  "@enterEndpointUseByNetwork": {
+    "type": "text",
+    "placeholders_order": [],
+    "placeholders": {}
+  },
   "enterEndpointHeader": "Please, specify your endpoint",
   "@enterEndpointHeader": {
     "type": "text",

--- a/lib/l10n/intl_messages.arb
+++ b/lib/l10n/intl_messages.arb
@@ -1,5 +1,5 @@
 {
-  "@@last_modified": "2023-01-26T09:11:55.691638",
+  "@@last_modified": "2023-01-22T20:39:35.083978",
   "noConnectionBanner": "No connection",
   "@noConnectionBanner": {
     "type": "text",

--- a/lib/l10n/messages_en.dart
+++ b/lib/l10n/messages_en.dart
@@ -151,6 +151,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "enterEndpointBlank" : MessageLookupByLibrary.simpleMessage("The endpoint cannot be empty"),
     "enterEndpointHeader" : MessageLookupByLibrary.simpleMessage("Please, specify your endpoint"),
     "enterEndpointNotValid" : MessageLookupByLibrary.simpleMessage("The endpoint is not valid"),
+    "enterEndpointUseByNetwork" : MessageLookupByLibrary.simpleMessage("The endpoint is already used by a network"),
     "enterPasswordHint" : MessageLookupByLibrary.simpleMessage("Enter your password"),
     "enterPublicKey" : MessageLookupByLibrary.simpleMessage("Enter Public Key"),
     "enterYubikeyAPIKeyEmpty" : MessageLookupByLibrary.simpleMessage("The API Key is mandatory"),

--- a/lib/l10n/messages_fr.dart
+++ b/lib/l10n/messages_fr.dart
@@ -151,6 +151,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "enterEndpointBlank" : MessageLookupByLibrary.simpleMessage("Le point d\'accès est obligatoire."),
     "enterEndpointHeader" : MessageLookupByLibrary.simpleMessage("Veuillez préciser votre point d\'accès."),
     "enterEndpointNotValid" : MessageLookupByLibrary.simpleMessage("Le point d\'accès n\'est pas valide."),
+    "enterEndpointUseByNetwork" : MessageLookupByLibrary.simpleMessage("Le point d\'accès est déjà utilisé par un réseau."),
     "enterPasswordHint" : MessageLookupByLibrary.simpleMessage("Saisissez votre mot de passe"),
     "enterPublicKey" : MessageLookupByLibrary.simpleMessage("Enter la clé publique"),
     "enterYubikeyAPIKeyEmpty" : MessageLookupByLibrary.simpleMessage("La clé client de l\'API est obligatoire"),

--- a/lib/l10n/messages_messages.dart
+++ b/lib/l10n/messages_messages.dart
@@ -152,6 +152,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "enterEndpointBlank" : MessageLookupByLibrary.simpleMessage("The endpoint cannot be empty"),
     "enterEndpointHeader" : MessageLookupByLibrary.simpleMessage("Please, specify your endpoint"),
     "enterEndpointNotValid" : MessageLookupByLibrary.simpleMessage("The endpoint is not valid"),
+    "enterEndpointUseByNetwork" : MessageLookupByLibrary.simpleMessage("The endpoint is already used by a network"),
     "enterPasswordHint" : MessageLookupByLibrary.simpleMessage("Enter your password"),
     "enterPublicKey" : MessageLookupByLibrary.simpleMessage("Enter Public Key"),
     "enterYubikeyAPIKeyEmpty" : MessageLookupByLibrary.simpleMessage("The API Key is mandatory"),

--- a/lib/localization.dart
+++ b/lib/localization.dart
@@ -303,6 +303,11 @@ class AppLocalization {
         name: 'enterEndpointNotValid');
   }
 
+  String get enterEndpointUseByNetwork {
+    return Intl.message('The endpoint is already used by a network',
+        name: 'enterEndpointUseByNetwork');
+  }
+
   String get enterEndpointHeader {
     return Intl.message('Please, specify your endpoint',
         name: 'enterEndpointHeader');

--- a/lib/model/available_networks.dart
+++ b/lib/model/available_networks.dart
@@ -4,6 +4,14 @@ import 'package:flutter/material.dart';
 
 enum AvailableNetworks { archethicMainNet, archethicTestNet, archethicDevNet }
 
+enum DefaultNetworksHost {
+  archethicMainNetHost('mainnet.archethic.net'),
+  archethicTestNetHost('testnet.archethic.net');
+
+  const DefaultNetworksHost(this.value);
+  final String value;
+}
+
 @immutable
 class NetworksSetting extends SettingSelectionItem {
   const NetworksSetting({
@@ -30,9 +38,9 @@ class NetworksSetting extends SettingSelectionItem {
   String getLink() {
     switch (network) {
       case AvailableNetworks.archethicMainNet:
-        return 'https://mainnet.archethic.net';
+        return 'https://${DefaultNetworksHost.archethicMainNetHost.value}';
       case AvailableNetworks.archethicTestNet:
-        return 'https://testnet.archethic.net';
+        return 'https://${DefaultNetworksHost.archethicTestNetHost.value}';
       case AvailableNetworks.archethicDevNet:
         return networkDevEndpoint;
     }
@@ -41,9 +49,9 @@ class NetworksSetting extends SettingSelectionItem {
   String getPhoenixHttpLink() {
     switch (network) {
       case AvailableNetworks.archethicMainNet:
-        return 'https://mainnet.archethic.net/socket/websocket';
+        return 'https://${DefaultNetworksHost.archethicMainNetHost.value}/socket/websocket';
       case AvailableNetworks.archethicTestNet:
-        return 'https://testnet.archethic.net/socket/websocket';
+        return 'https://${DefaultNetworksHost.archethicTestNetHost.value}/socket/websocket';
       case AvailableNetworks.archethicDevNet:
         return '$networkDevEndpoint/socket/websocket';
     }
@@ -52,9 +60,9 @@ class NetworksSetting extends SettingSelectionItem {
   String getWebsocketUri() {
     switch (network) {
       case AvailableNetworks.archethicMainNet:
-        return 'wss://mainnet.archethic.net/socket/websocket';
+        return 'wss://${DefaultNetworksHost.archethicMainNetHost.value}/socket/websocket';
       case AvailableNetworks.archethicTestNet:
-        return 'wss://testnet.archethic.net/socket/websocket';
+        return 'wss://${DefaultNetworksHost.archethicTestNetHost.value}/socket/websocket';
       case AvailableNetworks.archethicDevNet:
         return '${networkDevEndpoint.replaceAll('https:', 'ws:').replaceAll('http:', 'ws:')}/socket/websocket';
     }

--- a/lib/ui/widgets/dialogs/network_dialog.dart
+++ b/lib/ui/widgets/dialogs/network_dialog.dart
@@ -93,6 +93,31 @@ class NetworkDialog {
                               });
                             }
 
+                            Future<List<Node>> getNodeFromNetwork(
+                              AvailableNetworks network,
+                            ) async {
+                              final networkSetting = NetworksSetting(
+                                network: network,
+                                networkDevEndpoint: '',
+                              );
+
+                              final link = networkSetting.getLink();
+
+                              final nodeListMain = await ApiService(
+                                link,
+                              ).getNodeList();
+
+                              return nodeListMain;
+                            }
+
+                            bool hasUriInNode(Uri uri, List<Node> nodes) {
+                              return nodes.any(
+                                (node) =>
+                                    node.ip == uri.host &&
+                                    node.port == uri.port,
+                              );
+                            }
+
                             if (endpointController.text.isEmpty) {
                               setError(localizations.enterEndpointBlank);
                               return;
@@ -110,32 +135,28 @@ class NetworkDialog {
                             }
 
                             try {
-                              final nodeListMain = await ApiService(
-                                'https://mainnet.archethic.net',
-                              ).getNodeList();
+                              final nodeListMain = await getNodeFromNetwork(
+                                AvailableNetworks.archethicMainNet,
+                              );
 
-                              final nodeListTest = await ApiService(
-                                'https://testnet.archethic.net',
-                              ).getNodeList();
+                              final nodeListTest = await getNodeFromNetwork(
+                                AvailableNetworks.archethicTestNet,
+                              );
 
-                              if (nodeListMain.any(
-                                (node) =>
-                                    node.ip == uriInput.host &&
-                                    node.port == uriInput.port,
-                              )) {
-                                setError(localizations.enterEndpointNotValid);
+                              if (hasUriInNode(uriInput, nodeListMain)) {
+                                setError(
+                                  localizations.enterEndpointUseByNetwork,
+                                );
                                 return;
                               }
-                              if (nodeListTest.any(
-                                (node) =>
-                                    node.ip == uriInput.host &&
-                                    node.port == uriInput.port,
-                              )) {
-                                setError(localizations.enterEndpointNotValid);
+                              if (hasUriInNode(uriInput, nodeListTest)) {
+                                setError(
+                                  localizations.enterEndpointUseByNetwork,
+                                );
                                 return;
                               }
                             } catch (e) {
-                              setError(localizations.enterEndpointNotValid);
+                              setError(localizations.enterEndpointUseByNetwork);
                               return;
                             }
 

--- a/lib/ui/widgets/dialogs/network_dialog.dart
+++ b/lib/ui/widgets/dialogs/network_dialog.dart
@@ -1,4 +1,5 @@
 /// SPDX-License-Identifier: AGPL-3.0-or-later
+import 'package:aewallet/application/network/provider.dart';
 import 'package:aewallet/application/settings/settings.dart';
 import 'package:aewallet/application/settings/theme.dart';
 import 'package:aewallet/localization.dart';
@@ -93,31 +94,6 @@ class NetworkDialog {
                               });
                             }
 
-                            Future<List<Node>> getNodeFromNetwork(
-                              AvailableNetworks network,
-                            ) async {
-                              final networkSetting = NetworksSetting(
-                                network: network,
-                                networkDevEndpoint: '',
-                              );
-
-                              final link = networkSetting.getLink();
-
-                              final nodeListMain = await ApiService(
-                                link,
-                              ).getNodeList();
-
-                              return nodeListMain;
-                            }
-
-                            bool hasUriInNodes(Uri uri, List<Node> nodes) {
-                              return nodes.any(
-                                (node) =>
-                                    node.ip == uri.host &&
-                                    node.port == uri.port,
-                              );
-                            }
-
                             if (endpointController.text.isEmpty) {
                               setError(localizations.enterEndpointBlank);
                               return;
@@ -134,24 +110,13 @@ class NetworkDialog {
                               return;
                             }
 
-                            try {
-                              final nodeListMain = await getNodeFromNetwork(
-                                AvailableNetworks.archethicMainNet,
+                            if (await ref.watch(
+                              NetworkProvider.isReservedNodeUri(uri: uriInput)
+                                  .future,
+                            )) {
+                              setError(
+                                localizations.enterEndpointUseByNetwork,
                               );
-
-                              final nodeListTest = await getNodeFromNetwork(
-                                AvailableNetworks.archethicTestNet,
-                              );
-
-                              if (hasUriInNodes(uriInput, nodeListMain) ||
-                                  hasUriInNodes(uriInput, nodeListTest)) {
-                                setError(
-                                  localizations.enterEndpointUseByNetwork,
-                                );
-                                return;
-                              }
-                            } catch (e) {
-                              setError(localizations.enterEndpointUseByNetwork);
                               return;
                             }
 

--- a/lib/ui/widgets/dialogs/network_dialog.dart
+++ b/lib/ui/widgets/dialogs/network_dialog.dart
@@ -272,8 +272,8 @@ class _NetworkDevnetHeader extends ConsumerWidget {
           height: 30,
         ),
         Text(
-          ref.read(SettingsProviders.settings).network.getDisplayName(context),
           key: const Key('networkName'),
+          ref.read(SettingsProviders.settings).network.getDisplayName(context),
           style: theme.textStyleSize10W100Primary,
         ),
         const SizedBox(

--- a/lib/ui/widgets/dialogs/network_dialog.dart
+++ b/lib/ui/widgets/dialogs/network_dialog.dart
@@ -110,7 +110,7 @@ class NetworkDialog {
                               return nodeListMain;
                             }
 
-                            bool hasUriInNode(Uri uri, List<Node> nodes) {
+                            bool hasUriInNodes(Uri uri, List<Node> nodes) {
                               return nodes.any(
                                 (node) =>
                                     node.ip == uri.host &&
@@ -143,13 +143,8 @@ class NetworkDialog {
                                 AvailableNetworks.archethicTestNet,
                               );
 
-                              if (hasUriInNode(uriInput, nodeListMain)) {
-                                setError(
-                                  localizations.enterEndpointUseByNetwork,
-                                );
-                                return;
-                              }
-                              if (hasUriInNode(uriInput, nodeListTest)) {
+                              if (hasUriInNodes(uriInput, nodeListMain) ||
+                                  hasUriInNodes(uriInput, nodeListTest)) {
                                 setError(
                                   localizations.enterEndpointUseByNetwork,
                                 );
@@ -211,7 +206,7 @@ class _NetworkDialogCustomInput extends ConsumerWidget {
     return _NetworkAlertDialog(
       title: const Padding(
         padding: EdgeInsets.only(bottom: 10),
-        child: _NetworkDevnetLogo(),
+        child: _NetworkDevnetHeader(),
       ),
       content: Column(
         mainAxisSize: MainAxisSize.min,
@@ -305,8 +300,8 @@ class _NetworkTitle extends ConsumerWidget {
   }
 }
 
-class _NetworkDevnetLogo extends ConsumerWidget {
-  const _NetworkDevnetLogo();
+class _NetworkDevnetHeader extends ConsumerWidget {
+  const _NetworkDevnetHeader();
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/ui/widgets/dialogs/network_dialog.dart
+++ b/lib/ui/widgets/dialogs/network_dialog.dart
@@ -6,11 +6,11 @@ import 'package:aewallet/localization.dart';
 import 'package:aewallet/model/available_networks.dart';
 import 'package:aewallet/ui/util/dimens.dart';
 import 'package:aewallet/ui/util/styles.dart';
+import 'package:aewallet/ui/util/ui_util.dart';
 import 'package:aewallet/ui/widgets/components/app_button_tiny.dart';
 import 'package:aewallet/ui/widgets/components/app_text_field.dart';
 import 'package:aewallet/ui/widgets/components/picker_item.dart';
 import 'package:aewallet/util/service_locator.dart';
-import 'package:archethic_lib_dart/archethic_lib_dart.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -26,7 +26,6 @@ class NetworkDialog {
     final localizations = AppLocalization.of(context)!;
     final endpointFocusNode = FocusNode();
     final endpointController = TextEditingController();
-    String? endpointError;
 
     final pickerItemsList = List<PickerItem>.empty(growable: true);
     for (final value in AvailableNetworks.values) {
@@ -83,15 +82,15 @@ class NetworkDialog {
                         return _NetworkDialogCustomInput(
                           endpointFocusNode: endpointFocusNode,
                           endpointController: endpointController,
-                          endpointError: endpointError,
                           onSubmitNetwork: () async {
                             void setError(String errorText) {
-                              setState(() {
-                                endpointError = errorText;
-                                FocusScope.of(context).requestFocus(
-                                  endpointFocusNode,
-                                );
-                              });
+                              UIUtil.showSnackbar(
+                                errorText,
+                                context,
+                                ref,
+                                theme.text!,
+                                theme.snackBarShadow!,
+                              );
                             }
 
                             if (endpointController.text.isEmpty) {
@@ -154,13 +153,11 @@ class _NetworkDialogCustomInput extends ConsumerWidget {
   const _NetworkDialogCustomInput({
     required this.endpointFocusNode,
     required this.endpointController,
-    required this.endpointError,
     required this.onSubmitNetwork,
   });
 
   final FocusNode endpointFocusNode;
   final TextEditingController endpointController;
-  final String? endpointError;
   final Function() onSubmitNetwork;
 
   @override
@@ -189,19 +186,14 @@ class _NetworkDialogCustomInput extends ConsumerWidget {
                 keyboardType: TextInputType.text,
                 style: theme.textStyleSize14W600Primary,
                 inputFormatters: <TextInputFormatter>[
-                  LengthLimitingTextInputFormatter(28),
+                  LengthLimitingTextInputFormatter(200),
                 ],
               ),
               Text(
                 'http://xxx.xxx.xxx.xxx:xxxx',
                 style: theme.textStyleSize12W400Primary,
               ),
-              if (endpointError != null)
-                _NetworkErrorMessage(
-                  endpointError: endpointError,
-                )
-              else
-                const SizedBox(),
+              const SizedBox(),
             ],
           ),
           const SizedBox(
@@ -292,30 +284,6 @@ class _NetworkDevnetHeader extends ConsumerWidget {
           style: theme.textStyleSize16W400Primary,
         ),
       ],
-    );
-  }
-}
-
-class _NetworkErrorMessage extends ConsumerWidget {
-  const _NetworkErrorMessage({
-    required this.endpointError,
-  });
-
-  final String? endpointError;
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final theme = ref.watch(ThemeProviders.selectedTheme);
-
-    return Container(
-      margin: const EdgeInsets.only(
-        top: 5,
-        bottom: 5,
-      ),
-      child: Text(
-        endpointError!,
-        style: theme.textStyleSize14W600Primary,
-      ),
     );
   }
 }


### PR DESCRIPTION
It is currently in: Work In Progress.

Link issue: https://github.com/archethic-foundation/archethic-wallet/issues/507

Ask for this issue:

- Check if url was correctly formated (For me, it was already the case)
- Check if url enter by the user was in the list of used url by the network.

What I have done:

- Refacto code to split in multiples components
- Improve readability of "onPressed" to check custom url

What blocks me:

- When I try to get the nodes. I have an error: ArchethicConnectionException
`responseHttp.error={
"linkException": "ServerException(originalException: Connection refused, originalStackTrace: #0      IOClient.send (package:http/src/io_client.dart:88:7)\n<asynchronous suspension>\n#1      HttpLink._executeRequest (package:gql_http_link/src/link.dart:131:24)\n<asynchronous suspension>\n#2      HttpLink.request (package:gql_http_link/src/link.dart:76:26)\n<asynchronous suspension>\n#3      Stream.first.<anonymous closure> (dart:async/stream.dart:1586:25)\n<asynchronous suspension>\n, parsedResponse: null)"`
