### PR TITLE
🐛Fix NFT RenderFlex overflowed

### DIFF
--- a/lib/ui/views/nft_creation/layouts/components/nft_creation_process_import_tab.dart
+++ b/lib/ui/views/nft_creation/layouts/components/nft_creation_process_import_tab.dart
@@ -30,7 +30,6 @@ class _NFTCreationProcessImportTabState
       child: Container(
         padding:
             EdgeInsets.only(top: 20, left: 20, right: 20, bottom: bottom + 80),
-        height: MediaQuery.of(context).size.height,
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [


### PR DESCRIPTION
# Description

This PR solves issue #665 by removing height constrain.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Material used:

Please delete options that are not relevant.
- Android (Smartphone/Tablet)
- Windows

## How Has This Been Tested?

- Used a Pixel 2 emulator to run our app to check if the image overflows or not in small screen devices.

### Patrol


## Checklist:

- [x]My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Useful info for the reviewer:
I will try to make clean commits now onwards.