### PR TITLE
Generate a specific aes key for each secret

### DIFF
--- a/lib/infrastructure/repositories/transaction_token_builder.dart
+++ b/lib/infrastructure/repositories/transaction_token_builder.dart
@@ -26,15 +26,6 @@ extension AddTokenTransactionBuilder on archethic.Transaction {
       data: archethic.Transaction.initData(),
     );
 
-    var aesKey = '';
-    if (tokenProperties.isNotEmpty) {
-      aesKey = archethic.uint8ListToHex(
-        Uint8List.fromList(
-          List<int>.generate(32, (int i) => Random.secure().nextInt(256)),
-        ),
-      );
-    }
-
     final tokenPropertiesNotProtected = <String, dynamic>{};
     for (final tokenProperty in tokenProperties) {
       if (tokenProperty.publicKeys.isEmpty) {
@@ -49,6 +40,12 @@ extension AddTokenTransactionBuilder on archethic.Transaction {
             publicKey.publicKey,
           );
         }
+
+        final aesKey = archethic.uint8ListToHex(
+          Uint8List.fromList(
+            List<int>.generate(32, (int i) => Random.secure().nextInt(256)),
+          ),
+        );
 
         final authorizedKeys =
             List<archethic.AuthorizedKey>.empty(growable: true);
@@ -67,7 +64,11 @@ extension AddTokenTransactionBuilder on archethic.Transaction {
             tokenProperty.propertyValue;
         transaction.addOwnership(
           archethic.uint8ListToHex(
-            archethic.aesEncrypt(json.encode(tokenPropertiesProtected), aesKey),
+            archethic.aesEncrypt(
+              json.encode(tokenPropertiesProtected),
+              aesKey,
+              isDataHexa: false,
+            ),
           ),
           authorizedKeys,
         );

--- a/lib/model/data/account.dart
+++ b/lib/model/data/account.dart
@@ -13,8 +13,6 @@ import 'package:hive/hive.dart';
 
 part 'account.g.dart';
 
-enum ServiceType { archethicWallet, aeweb, other }
-
 /// Next field available : 14
 @HiveType(typeId: 1)
 class Account extends HiveObject {
@@ -346,14 +344,14 @@ mixin KeychainServiceMixin {
   final kDerivationPathAEWebWithoutService = "m/650'/aeweb-";
   final kDerivationPathOtherWithoutService = "m/650'/";
 
-  ServiceType getServiceTypeFromPath(String derivationPath) {
-    var serviceType = ServiceType.other;
+  String getServiceTypeFromPath(String derivationPath) {
+    var serviceType = 'other';
     if (derivationPath
         .startsWith(kDerivationPathArchethicWalletWithoutService)) {
-      serviceType = ServiceType.archethicWallet;
+      serviceType = 'archethicWallet';
     } else {
       if (derivationPath.startsWith(kDerivationPathAEWebWithoutService)) {
-        serviceType = ServiceType.aeweb;
+        serviceType = 'aeweb';
       }
     }
     return serviceType;
@@ -363,13 +361,13 @@ mixin KeychainServiceMixin {
     final serviceType = getServiceTypeFromPath(derivationPath);
     late List<String> path;
 
-    if (serviceType == ServiceType.archethicWallet) {
+    if (serviceType == 'archethicWallet') {
       path = derivationPath
           .replaceAll(kDerivationPathArchethicWalletWithoutService, '')
           .split('/')
         ..last = '';
     } else {
-      if (serviceType == ServiceType.aeweb) {
+      if (serviceType == 'aeweb') {
         path = derivationPath
             .replaceAll(kDerivationPathAEWebWithoutService, '')
             .split('/')

--- a/lib/service/app_service.dart
+++ b/lib/service/app_service.dart
@@ -1168,7 +1168,7 @@ class AppService {
 
     final token = tokenMap[address]!;
 
-    final tokenWithoutFile = token.properties
+    final tokenWithoutFile = {...token.properties}
       ..removeWhere((key, value) => key == 'content');
 
     if (secretMap[address] != null &&

--- a/lib/ui/util/service_type_formatters.dart
+++ b/lib/ui/util/service_type_formatters.dart
@@ -1,6 +1,5 @@
 /// SPDX-License-Identifier: AGPL-3.0-or-later
 import 'package:aewallet/localization.dart';
-import 'package:aewallet/model/data/account.dart';
 import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
@@ -14,42 +13,26 @@ class ServiceTypeFormatters {
   String getLabel(BuildContext context) {
     final localizations = AppLocalization.of(context)!;
 
-    switch (_serviceType.serviceType) {
-      case ServiceType.aeweb:
+    switch (serviceType) {
+      case 'aeweb':
         return localizations.serviceTypeLabelAeweb;
-      case ServiceType.archethicWallet:
+      case 'archethicWallet':
         return localizations.serviceTypeLabelArchethicWallet;
-      case ServiceType.other:
+      case 'other':
+      default:
         return localizations.serviceTypeLabelOther;
-      case null:
-        return '';
     }
   }
 
   IconData getIcon() {
-    switch (_serviceType.serviceType) {
-      case ServiceType.aeweb:
-        return FontAwesomeIcons.globe;
-      case ServiceType.archethicWallet:
-        return Icons.account_balance_wallet_outlined;
-      case ServiceType.other:
-        return Icons.help_center_outlined;
-      case null:
-        return Icons.help_center_outlined;
-    }
-  }
-}
-
-extension ServiceString on String {
-  ServiceType? get serviceType {
-    switch (this) {
-      case 'archethicWallet':
-        return ServiceType.archethicWallet;
+    switch (_serviceType) {
       case 'aeweb':
-        return ServiceType.aeweb;
+        return FontAwesomeIcons.globe;
+      case 'archethicWallet':
+        return Icons.account_balance_wallet_outlined;
       case 'other':
-        return ServiceType.other;
+      default:
+        return Icons.help_center_outlined;
     }
-    return null;
   }
 }

--- a/lib/ui/views/accounts/layouts/components/account_list_item.dart
+++ b/lib/ui/views/accounts/layouts/components/account_list_item.dart
@@ -38,7 +38,7 @@ class AccountListItem extends ConsumerWidget {
         ref.watch(PrimaryCurrencyProviders.selectedPrimaryCurrency);
 
     AsyncValue<Contact>? contact;
-    if (account.serviceType != ServiceType.other) {
+    if (account.serviceType != 'other') {
       contact = ref.watch(
         ContactProviders.getContactWithName(
           account.name,
@@ -66,7 +66,7 @@ class AccountListItem extends ConsumerWidget {
       padding: const EdgeInsets.only(bottom: 8),
       child: GestureDetector(
         onTap: () async {
-          if (account.serviceType == ServiceType.archethicWallet) {
+          if (account.serviceType == 'archethicWallet') {
             sl.get<HapticUtil>().feedback(
                   FeedbackType.light,
                   ref.read(
@@ -94,7 +94,7 @@ class AccountListItem extends ConsumerWidget {
           }
         },
         onLongPress: () {
-          if (account.serviceType != ServiceType.other) {
+          if (account.serviceType != 'other') {
             return contact!.map(
               data: (data) {
                 sl.get<HapticUtil>().feedback(
@@ -124,11 +124,11 @@ class AccountListItem extends ConsumerWidget {
             borderRadius: BorderRadius.circular(10),
           ),
           elevation: 0,
-          color: account.serviceType == ServiceType.archethicWallet
+          color: account.serviceType == 'archethicWallet'
               ? theme.backgroundAccountsListCardSelected
               : Colors.transparent,
           child: Container(
-            height: account.serviceType != ServiceType.aeweb ? 85 : 55,
+            height: account.serviceType != 'aeweb' ? 85 : 55,
             color: account.selected!
                 ? theme.backgroundAccountsListCardSelected
                 : theme.backgroundAccountsListCard,
@@ -168,7 +168,7 @@ class AccountListItem extends ConsumerWidget {
                     ],
                   ),
                 ),
-                if (account.serviceType != ServiceType.aeweb.toString())
+                if (account.serviceType != 'aeweb')
                   if (settings.showBalances)
                     primaryCurrency.primaryCurrency ==
                             AvailablePrimaryCurrencyEnum.native
@@ -217,12 +217,12 @@ class AccountListItem extends ConsumerWidget {
                           '···········',
                           style: theme.textStyleSize12W600Primary60,
                         ),
-                        if (account.serviceType != ServiceType.aeweb)
+                        if (account.serviceType != 'aeweb')
                           AutoSizeText(
                             '···········',
                             style: theme.textStyleSize12W600Primary60,
                           ),
-                        if (account.serviceType != ServiceType.aeweb)
+                        if (account.serviceType != 'aeweb')
                           AutoSizeText(
                             '···········',
                             style: theme.textStyleSize12W600Primary60,

--- a/lib/util/keychain_util.dart
+++ b/lib/util/keychain_util.dart
@@ -186,7 +186,7 @@ class KeychainUtil with KeychainServiceMixin {
             nativeTokenValue: 0,
           ),
           recentTransactions: [],
-          serviceType: serviceType.toString(),
+          serviceType: serviceType,
         );
         if (selectedAccount != null && selectedAccount.name == nameDecoded) {
           account.selected = true;
@@ -207,7 +207,7 @@ class KeychainUtil with KeychainServiceMixin {
 
         accounts.add(account);
 
-        if (serviceType == ServiceType.archethicWallet) {
+        if (serviceType == 'archethicWallet') {
           try {
             await sl.get<DBHelper>().getContactWithName(account.name);
           } catch (e) {


### PR DESCRIPTION
# Description

Generation of AES Key for each NFT's private properties instead of only one for all private properties of one NFT.

Fixes #676 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Material used:

Please delete options that are not relevant.
- iOS (Smartphone/Tablet)

## How Has This Been Tested?

Creation of an NFT with several private properties. Each property refers to different contacts
When each contact consults the NFT, it only sees the public and private properties that concern it

## Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
