### PR TITLE
:bug: Fix RPC server activation settings.

### DIFF
--- a/lib/domain/repositories/feature_flags.dart
+++ b/lib/domain/repositories/feature_flags.dart
@@ -1,4 +1,0 @@
-/// Simply activate/deactivate features.
-class FeatureFlags {
-  static const rpcEnabled = true;
-}

--- a/lib/ui/menu/settings_drawer/security_menu_view.dart
+++ b/lib/ui/menu/settings_drawer/security_menu_view.dart
@@ -82,11 +82,9 @@ class SecurityMenuView extends ConsumerWidget {
                       const _SettingsListItem.spacer(),
                       const _BackupSecretPhraseListItem(),
                       const _SettingsListItem.spacer(),
-                      if (FeatureFlags.rpcEnabled &&
-                          ArchethicWebsocketRPCServer.isPlatformCompatible)
+                      if (ArchethicWebsocketRPCServer.isPlatformCompatible)
                         const _ActiveServerRPCSettingsListItem(),
-                      if (FeatureFlags.rpcEnabled &&
-                          ArchethicWebsocketRPCServer.isPlatformCompatible)
+                      if (ArchethicWebsocketRPCServer.isPlatformCompatible)
                         const _SettingsListItem.spacer(),
                       const _PinPadShuffleSettingsListItem(),
                       const _SettingsListItem.spacer(),

--- a/lib/ui/menu/settings_drawer/security_menu_view.dart
+++ b/lib/ui/menu/settings_drawer/security_menu_view.dart
@@ -412,13 +412,9 @@ class _ActiveServerRPCSettingsListItem extends ConsumerWidget {
       onChanged: (bool isSwitched) async {
         await preferencesNotifier.setActiveRPCServer(isSwitched);
         if (isSwitched) {
-          await ArchethicWebsocketRPCServer(
-            commandDispatcher: sl.get<CommandDispatcher>(),
-          ).run();
+          await sl.get<ArchethicWebsocketRPCServer>().run();
         } else {
-          await ArchethicWebsocketRPCServer(
-            commandDispatcher: sl.get<CommandDispatcher>(),
-          ).stop();
+          await sl.get<ArchethicWebsocketRPCServer>().stop();
         }
       },
     );

--- a/lib/ui/menu/settings_drawer/settings_drawer.dart
+++ b/lib/ui/menu/settings_drawer/settings_drawer.dart
@@ -12,8 +12,6 @@ import 'package:aewallet/application/settings/settings.dart';
 import 'package:aewallet/application/settings/theme.dart';
 import 'package:aewallet/application/settings/version.dart';
 import 'package:aewallet/application/wallet/wallet.dart';
-import 'package:aewallet/domain/repositories/feature_flags.dart';
-import 'package:aewallet/domain/rpc/command_dispatcher.dart';
 import 'package:aewallet/infrastructure/rpc/websocket_server.dart';
 import 'package:aewallet/model/authentication_method.dart';
 import 'package:aewallet/model/available_currency.dart';

--- a/lib/util/service_locator.dart
+++ b/lib/util/service_locator.dart
@@ -4,6 +4,7 @@ import 'package:aewallet/domain/rpc/command_dispatcher.dart';
 import 'package:aewallet/infrastructure/datasources/hive_preferences.dart';
 import 'package:aewallet/infrastructure/repositories/settings.dart';
 import 'package:aewallet/infrastructure/rpc/deeplink_server.dart';
+import 'package:aewallet/infrastructure/rpc/websocket_server.dart';
 import 'package:aewallet/model/data/appdb.dart';
 import 'package:aewallet/service/app_service.dart';
 import 'package:aewallet/util/biometrics_util.dart';
@@ -26,6 +27,9 @@ Future<void> setupServiceLocator() async {
     ..registerLazySingleton<LedgerNanoSImpl>(LedgerNanoSImpl.new)
     ..registerLazySingleton<CommandDispatcher>(
       CommandDispatcher.new,
+    )
+    ..registerLazySingleton<ArchethicWebsocketRPCServer>(
+      ArchethicWebsocketRPCServer.new,
     )
     ..registerLazySingleton<ArchethicDeeplinkRPCServer>(
       ArchethicDeeplinkRPCServer.new,


### PR DESCRIPTION
# Description

Add an option in the security menu to allow the users to activate or desactivate the RPC Server

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

## Material used:

- iOS (Mac)

## How Has This Been Tested?

Tested with AEWeb Dapp
Try to connect to AEWeb with and without the RPC Server availability
Try to publish a website with and without the RPC Server availability

## Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

## Useful info for the reviewer:
