### PR TITLE
:zap: Improve Tx signature popup display delay

### DIFF
--- a/lib/ui/views/rpc_command_receiver/transaction_raw.dart
+++ b/lib/ui/views/rpc_command_receiver/transaction_raw.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+
 import 'package:aewallet/domain/rpc/commands/sign_transactions.dart';
 import 'package:aewallet/ui/themes/themes.dart';
 import 'package:aewallet/ui/util/styles.dart';
@@ -56,31 +57,30 @@ class TransactionRawState extends State<TransactionRaw> {
             ],
           ),
         ),
-        AnimatedCrossFade(
+        AnimatedSwitcher(
           duration: const Duration(milliseconds: 300),
-          crossFadeState:
-              isExpanded ? CrossFadeState.showSecond : CrossFadeState.showFirst,
-          firstChild: const SizedBox.shrink(),
-          secondChild: SizedBox.fromSize(
-            child: Card(
-              shape: RoundedRectangleBorder(
-                side: BorderSide(
-                  color: widget.theme.backgroundTransferListOutline!,
-                ),
-                borderRadius: BorderRadius.circular(10),
-              ),
-              elevation: 0,
-              color: widget.theme.backgroundTransferListCard,
-              child: Padding(
-                padding: const EdgeInsets.all(10),
-                child: SelectableText(
-                  const JsonEncoder.withIndent('  ')
-                      .convert(widget.command.value.data),
-                  style: widget.theme.textStyleSize12W400Primary,
-                ),
-              ),
-            ),
-          ),
+          child: isExpanded
+              ? SizedBox.fromSize(
+                  child: Card(
+                    shape: RoundedRectangleBorder(
+                      side: BorderSide(
+                        color: widget.theme.backgroundTransferListOutline!,
+                      ),
+                      borderRadius: BorderRadius.circular(10),
+                    ),
+                    elevation: 0,
+                    color: widget.theme.backgroundTransferListCard,
+                    child: Padding(
+                      padding: const EdgeInsets.all(10),
+                      child: SelectableText(
+                        const JsonEncoder.withIndent('  ')
+                            .convert(widget.command.value.data),
+                        style: widget.theme.textStyleSize12W400Primary,
+                      ),
+                    ),
+                  ),
+                )
+              : const SizedBox.shrink(),
         ),
       ],
     );


### PR DESCRIPTION
# Description

Transaction signature popup freezes when displayed with heavy transactions.
Analysis shows that `Text` layout with a 3Mo payload is responsible for the freeze.

So, the fix only lazy loads/layouts transaction content on user request. That way, popup initial display does not freeze.
