### PR TITLE
754 recent transactions disappear on main tab when a new account is created by rpc command

### DIFF
--- a/lib/application/account/accounts_notifier.dart
+++ b/lib/application/account/accounts_notifier.dart
@@ -11,14 +11,9 @@ class _AccountsNotifier extends AutoDisposeAsyncNotifier<List<Account>> {
 
     // Init avec la valeur du cache
     final repository = ref.watch(AccountProviders.accountsRepository);
-    final accountNames = await repository.accountNames();
+    final accountNames = await repository.accounts();
 
-    return [
-      for (final accountName in accountNames)
-        await ref.watch(
-          AccountProviders.account(accountName).future,
-        ),
-    ].whereType<Account>().toList();
+    return accountNames.whereType<Account>().toList();
   }
 
   Future<void> selectAccount(Account account) async {

--- a/lib/domain/repositories/account.dart
+++ b/lib/domain/repositories/account.dart
@@ -1,7 +1,7 @@
 import 'package:aewallet/model/data/account.dart';
 
 abstract class AccountLocalRepositoryInterface {
-  Future<List<String>> accountNames();
+  Future<List<Account>> accounts();
 
   Future<Account?> getAccount(String name);
 

--- a/lib/infrastructure/repositories/local_account.dart
+++ b/lib/infrastructure/repositories/local_account.dart
@@ -7,13 +7,9 @@ class AccountLocalRepository implements AccountLocalRepositoryInterface {
   final DBHelper _dbHelper = sl.get<DBHelper>();
 
   @override
-  Future<List<String>> accountNames() async {
+  Future<List<Account>> accounts() async {
     final accounts = await _dbHelper.getAccounts();
-    return accounts
-        .map(
-          (account) => account.name,
-        )
-        .toList();
+    return accounts;
   }
 
   @override

--- a/lib/ui/views/accounts/layouts/account_list.dart
+++ b/lib/ui/views/accounts/layouts/account_list.dart
@@ -66,7 +66,6 @@ class AccountsListWidget extends ConsumerWidget {
             ),
             itemCount: accountsList.length,
             itemBuilder: (BuildContext context, int index) {
-              // Build contact
               return AccountListItem(
                 account: accountsList[index],
               )

--- a/lib/ui/views/rpc_command_receiver/add_service/command_handler.dart
+++ b/lib/ui/views/rpc_command_receiver/add_service/command_handler.dart
@@ -99,6 +99,10 @@ class AddServiceHandler extends CommandHandler {
                         await ref
                             .read(SessionProviders.session.notifier)
                             .refresh();
+
+                        await ref
+                            .read(AccountProviders.selectedAccount.notifier)
+                            .refreshRecentTransactions();
                       }
                     });
 

--- a/lib/util/keychain_util.dart
+++ b/lib/util/keychain_util.dart
@@ -188,7 +188,9 @@ class KeychainUtil with KeychainServiceMixin {
           recentTransactions: [],
           serviceType: serviceType,
         );
-        if (selectedAccount != null && selectedAccount.name == nameDecoded) {
+        if (selectedAccount != null &&
+            selectedAccount.name == nameDecoded &&
+            serviceType == 'archethicWallet') {
           account.selected = true;
         } else {
           account.selected = false;


### PR DESCRIPTION
# Description

Fixes 
https://github.com/archethic-foundation/archethic-wallet/issues/754
+
Fix of account display when there is a duplicate account name in the keychain at(excluding prefixes)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Material used:

Please delete options that are not relevant.
- iOS (Mac)

## How Has This Been Tested?

Creation of a same account name between AEWeb and AEWallet and check no doublon is displayed
Creation of a website on AEWeb and check the recent tx in the wallet is not empty

## Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

## Useful info for the reviewer:
