### PR TITLE
Recovery Phrase Management

### DIFF
--- a/lib/application/recovery_phrase_saved.dart
+++ b/lib/application/recovery_phrase_saved.dart
@@ -1,0 +1,28 @@
+/// SPDX-License-Identifier: AGPL-3.0-or-later
+import 'package:aewallet/infrastructure/datasources/hive_preferences.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'recovery_phrase_saved.g.dart';
+
+@riverpod
+Future<bool> _isRecoveryPhraseSaved(
+  _IsRecoveryPhraseSavedRef ref,
+) async {
+  final preferences = await HivePreferencesDatasource.getInstance();
+  return preferences.getRecoveryPhraseSaved();
+}
+
+@riverpod
+Future<void> _setRecoveryPhraseSaved(
+  _SetRecoveryPhraseSavedRef ref,
+  bool value,
+) async {
+  final preferences = await HivePreferencesDatasource.getInstance();
+  await preferences.setRecoveryPhraseSaved(value);
+  ref.invalidate(RecoveryPhraseSavedProvider.isRecoveryPhraseSaved);
+}
+
+abstract class RecoveryPhraseSavedProvider {
+  static final isRecoveryPhraseSaved = _isRecoveryPhraseSavedProvider;
+  static const setRecoveryPhraseSaved = _setRecoveryPhraseSavedProvider;
+}

--- a/lib/application/recovery_phrase_saved.g.dart
+++ b/lib/application/recovery_phrase_saved.g.dart
@@ -1,0 +1,130 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'recovery_phrase_saved.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$isRecoveryPhraseSavedHash() =>
+    r'e74fe27f4e109056a3fc68bc6793e9edf1eb878a';
+
+/// See also [_isRecoveryPhraseSaved].
+@ProviderFor(_isRecoveryPhraseSaved)
+final _isRecoveryPhraseSavedProvider = AutoDisposeFutureProvider<bool>.internal(
+  _isRecoveryPhraseSaved,
+  name: r'_isRecoveryPhraseSavedProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$isRecoveryPhraseSavedHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _IsRecoveryPhraseSavedRef = AutoDisposeFutureProviderRef<bool>;
+String _$setRecoveryPhraseSavedHash() =>
+    r'd149ec4155d979322fa510fbbe64bd6e88dee9af';
+
+/// Copied from Dart SDK
+class _SystemHash {
+  _SystemHash._();
+
+  static int combine(int hash, int value) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + value);
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
+    return hash ^ (hash >> 6);
+  }
+
+  static int finish(int hash) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
+    // ignore: parameter_assignments
+    hash = hash ^ (hash >> 11);
+    return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
+  }
+}
+
+typedef _SetRecoveryPhraseSavedRef = AutoDisposeFutureProviderRef<void>;
+
+/// See also [_setRecoveryPhraseSaved].
+@ProviderFor(_setRecoveryPhraseSaved)
+const _setRecoveryPhraseSavedProvider = _SetRecoveryPhraseSavedFamily();
+
+/// See also [_setRecoveryPhraseSaved].
+class _SetRecoveryPhraseSavedFamily extends Family<AsyncValue<void>> {
+  /// See also [_setRecoveryPhraseSaved].
+  const _SetRecoveryPhraseSavedFamily();
+
+  /// See also [_setRecoveryPhraseSaved].
+  _SetRecoveryPhraseSavedProvider call(
+    bool value,
+  ) {
+    return _SetRecoveryPhraseSavedProvider(
+      value,
+    );
+  }
+
+  @override
+  _SetRecoveryPhraseSavedProvider getProviderOverride(
+    covariant _SetRecoveryPhraseSavedProvider provider,
+  ) {
+    return call(
+      provider.value,
+    );
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'_setRecoveryPhraseSavedProvider';
+}
+
+/// See also [_setRecoveryPhraseSaved].
+class _SetRecoveryPhraseSavedProvider extends AutoDisposeFutureProvider<void> {
+  /// See also [_setRecoveryPhraseSaved].
+  _SetRecoveryPhraseSavedProvider(
+    this.value,
+  ) : super.internal(
+          (ref) => _setRecoveryPhraseSaved(
+            ref,
+            value,
+          ),
+          from: _setRecoveryPhraseSavedProvider,
+          name: r'_setRecoveryPhraseSavedProvider',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : _$setRecoveryPhraseSavedHash,
+          dependencies: _SetRecoveryPhraseSavedFamily._dependencies,
+          allTransitiveDependencies:
+              _SetRecoveryPhraseSavedFamily._allTransitiveDependencies,
+        );
+
+  final bool value;
+
+  @override
+  bool operator ==(Object other) {
+    return other is _SetRecoveryPhraseSavedProvider && other.value == value;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, value.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member

--- a/lib/application/wallet/wallet.g.dart
+++ b/lib/application/wallet/wallet.g.dart
@@ -6,7 +6,7 @@ part of 'wallet.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$sessionNotifierHash() => r'0965981f8c0c7f155e44586de3e1b4e48680258d';
+String _$sessionNotifierHash() => r'b16698c219bb1aaa445b3ab76597cf336caa6e05';
 
 /// See also [_SessionNotifier].
 @ProviderFor(_SessionNotifier)

--- a/lib/infrastructure/datasources/hive_preferences.dart
+++ b/lib/infrastructure/datasources/hive_preferences.dart
@@ -41,6 +41,8 @@ class HivePreferencesDatasource {
   static const String priceChartScale = 'archethic_wallet_priceChartScale';
   static const String activeVibrations = 'archethic_wallet_activeVibrations';
   static const String activeRPCServer = 'archethic_wallet_activeRPCServer';
+  static const String recoveryPhraseSaved =
+      'archethic_wallet_recoveryPhraseSaved';
 
   static const String activeNotifications =
       'archethic_wallet_activeNotifications';
@@ -177,6 +179,12 @@ class HivePreferencesDatasource {
       _setValue(activeRPCServer, value);
 
   bool getActiveRPCServer() => _getValue(activeRPCServer, defaultValue: true);
+
+  Future<void> setRecoveryPhraseSaved(bool value) =>
+      _setValue(recoveryPhraseSaved, value);
+
+  bool getRecoveryPhraseSaved() =>
+      _getValue(recoveryPhraseSaved, defaultValue: false);
 
   Future<void> setMainScreenCurrentPage(int value) =>
       _setValue(mainScreenCurrentPage, value);

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -143,7 +143,7 @@
   "understandButton": "I understand",
   "confirmSecretPhrase": "Confirm your secret phrase.",
   "confirmSecretPhraseKo": "The order is not correct.",
-  "backupSecretPhrase": "Backup Secret Phrase",
+  "backupSecretPhrase": "Secret Recovery Phrase",
   "ok": "Ok",
   "addressInfos": "My public address to receive funds",
   "informations": "Informations",
@@ -557,5 +557,9 @@
       }
     }
   },
-  "searchDiscussionHint": "Search from an address"
+  "searchDiscussionHint": "Search from an address",
+  "passRecoveryPhraseBackupSecureLater": "Remind me later",
+  "passRecoveryPhraseBackupSecureNow": "Secure my wallet now",
+  "recoveryPhraseBackupRequired": "Save your secret recovery phrase to protect your wallet and associated funds",
+  "recoveryPhraseSave": "Save secret phrase"
 }

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -143,7 +143,7 @@
 	"understandButton": "Je comprends",
 	"confirmSecretPhrase": "Confirmez votre phrase secrète.",
 	"confirmSecretPhraseKo": "L'ordre n'est pas correct.",
-	"backupSecretPhrase": "Phrase secrète de sauvegarde",
+	"backupSecretPhrase": "Phrase secrète de de récupération",
 	"ok": "Ok",
 	"addressInfos": "Mon adresse publique pour recevoir des fonds",
 	"informations": "Informations",
@@ -352,7 +352,7 @@
 	"messageInvalid": "Votre message ne peut pas comporter (pour le moment) des caractères spéciaux.",
 	"pass": "Passer",
 	"passBackupConfirmationDisclaimer": "CLAUSE DE NON-RESPONSABILITE",
-	"passBackupConfirmationMessage": "Nous vous invitons à confirmer manuellement l'enregistrement de votre recovery phrase. En cas de perte, vous perdrez vos fonds.",
+	"passBackupConfirmationMessage": "Nous vous invitons à confirmer manuellement l'enregistrement de votre phrase secrète de récupération. En cas de perte, vous perdrez vos fonds.",
 	"archethicDoesntKeepCopy": "Pour rappel, Archethic n'en garde aucune copie.",
 	"accountsKeychainAddressHeader": "Adresse de votre porte-clés",
 	"amountZero": "Le montant doit être > 0",
@@ -534,5 +534,9 @@
 			}
 		}
 	},
-	"searchDiscussionHint": "Rechercher à partir d'une adresse"
+	"searchDiscussionHint": "Rechercher à partir d'une adresse",
+	"passRecoveryPhraseBackupSecureLater": "Me le rappeler plus tard",
+	"passRecoveryPhraseBackupSecureNow": "Sécuriser mon portefeuille maintenant",
+	"recoveryPhraseBackupRequired": "Sauvegardez votre phrase secrète de récupération pour protéger votre portefeuille et les fonds associés",
+	"recoveryPhraseSave": "Sauvegarder la phrase secrète"
 }

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -143,7 +143,7 @@
 	"understandButton": "Je comprends",
 	"confirmSecretPhrase": "Confirmez votre phrase secrète.",
 	"confirmSecretPhraseKo": "L'ordre n'est pas correct.",
-	"backupSecretPhrase": "Phrase secrète de de récupération",
+	"backupSecretPhrase": "Phrase secrète de récupération",
 	"ok": "Ok",
 	"addressInfos": "Mon adresse publique pour recevoir des fonds",
 	"informations": "Informations",

--- a/lib/ui/util/info_banner.dart
+++ b/lib/ui/util/info_banner.dart
@@ -1,0 +1,64 @@
+/// SPDX-License-Identifier: AGPL-3.0-or-later
+import 'package:aewallet/application/settings/theme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class InfoBanner extends ConsumerWidget {
+  const InfoBanner(
+    this.message, {
+    this.height = 50.0,
+    this.fontSize = 12.0,
+    super.key,
+  });
+
+  final String message;
+  final double height;
+  final double fontSize;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (message.isEmpty) {
+      return SizedBox(
+        height: height,
+      );
+    }
+    final theme = ref.watch(ThemeProviders.selectedTheme);
+
+    return Container(
+      alignment: Alignment.center,
+      color: Colors.transparent,
+      width: MediaQuery.of(context).size.width,
+      height: height,
+      child: Padding(
+        padding: const EdgeInsets.only(left: 5, right: 5),
+        child: Card(
+          shape: RoundedRectangleBorder(
+            side: BorderSide(
+              color: theme.text!.withOpacity(0.4),
+            ),
+            borderRadius: BorderRadius.circular(10),
+          ),
+          elevation: 0,
+          color: theme.background,
+          child: Container(
+            padding: const EdgeInsets.only(
+              top: 5,
+              bottom: 5,
+              left: 10,
+              right: 10,
+            ),
+            width: MediaQuery.of(context).size.width,
+            alignment: Alignment.center,
+            child: Text(
+              message,
+              style: TextStyle(
+                color: theme.text,
+                fontSize: fontSize,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/util/info_banner.dart
+++ b/lib/ui/util/info_banner.dart
@@ -30,7 +30,7 @@ class InfoBanner extends ConsumerWidget {
       width: MediaQuery.of(context).size.width,
       height: height,
       child: Padding(
-        padding: const EdgeInsets.only(left: 5, right: 5),
+        padding: const EdgeInsets.symmetric(horizontal: 5),
         child: Card(
           shape: RoundedRectangleBorder(
             side: BorderSide(
@@ -41,12 +41,7 @@ class InfoBanner extends ConsumerWidget {
           elevation: 0,
           color: theme.background,
           child: Container(
-            padding: const EdgeInsets.only(
-              top: 5,
-              bottom: 5,
-              left: 10,
-              right: 10,
-            ),
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
             width: MediaQuery.of(context).size.width,
             alignment: Alignment.center,
             child: Text(

--- a/lib/ui/views/intro/intro_import_seed.dart
+++ b/lib/ui/views/intro/intro_import_seed.dart
@@ -4,6 +4,7 @@ import 'dart:developer';
 
 import 'package:aewallet/application/account/providers.dart';
 import 'package:aewallet/application/connectivity_status.dart';
+import 'package:aewallet/application/recovery_phrase_saved.dart';
 import 'package:aewallet/application/settings/settings.dart';
 import 'package:aewallet/application/settings/theme.dart';
 import 'package:aewallet/application/wallet/wallet.dart';
@@ -533,6 +534,10 @@ class _IntroImportSeedState extends ConsumerState<IntroImportSeedPage>
                                   ).notifier,
                                 )
                                 .refreshNFTs();
+                            ref.read(
+                              RecoveryPhraseSavedProvider
+                                  .setRecoveryPhraseSaved(true),
+                            );
                             final securityConfigOk =
                                 await launchSecurityConfiguration(
                               context,

--- a/lib/ui/views/main/components/recovery_phrase_banner.dart
+++ b/lib/ui/views/main/components/recovery_phrase_banner.dart
@@ -1,0 +1,75 @@
+import 'dart:core';
+
+import 'package:aewallet/application/authentication/authentication.dart';
+import 'package:aewallet/application/recovery_phrase_saved.dart';
+import 'package:aewallet/application/settings/settings.dart';
+import 'package:aewallet/application/wallet/wallet.dart';
+import 'package:aewallet/model/authentication_method.dart';
+import 'package:aewallet/ui/util/info_banner.dart';
+import 'package:aewallet/ui/views/authenticate/auth_factory.dart';
+import 'package:aewallet/ui/views/settings/backupseed_sheet.dart';
+import 'package:aewallet/ui/widgets/components/sheet_util.dart';
+import 'package:aewallet/util/mnemonics.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class RecoveryPhraseBanner extends ConsumerWidget {
+  const RecoveryPhraseBanner({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final recoveryPhraseSavedAsync =
+        ref.watch(RecoveryPhraseSavedProvider.isRecoveryPhraseSaved);
+
+    return recoveryPhraseSavedAsync.map(
+      data: (data) => data.value == false
+          ? Padding(
+              padding: const EdgeInsets.only(bottom: 80),
+              child: InkWell(
+                onTap: () async {
+                  final preferences = ref.read(SettingsProviders.settings);
+                  final authenticationSettings = ref.read(
+                    AuthenticationProviders.settings,
+                  );
+
+                  final auth = await AuthFactory.authenticate(
+                    context,
+                    ref,
+                    authMethod: AuthenticationMethod(
+                      authenticationSettings.authenticationMethod,
+                    ),
+                    activeVibrations: preferences.activeVibrations,
+                  );
+                  if (auth) {
+                    await ref.ensuresAutolockMaskHidden();
+
+                    final seed = ref
+                        .read(SessionProviders.session)
+                        .loggedIn
+                        ?.wallet
+                        .seed;
+                    final mnemonic = AppMnemomics.seedToMnemonic(
+                      seed!,
+                      languageCode: preferences.languageSeed,
+                    );
+
+                    Sheets.showAppHeightNineSheet(
+                      context: context,
+                      ref: ref,
+                      widget: AppSeedBackupSheet(mnemonic),
+                    );
+                  }
+                },
+                child: InfoBanner(
+                  AppLocalizations.of(context)!.recoveryPhraseBackupRequired,
+                  fontSize: 10,
+                ),
+              ),
+            )
+          : const SizedBox(),
+      error: (error) => const SizedBox(),
+      loading: (loading) => const SizedBox(),
+    );
+  }
+}

--- a/lib/ui/views/main/home_page.dart
+++ b/lib/ui/views/main/home_page.dart
@@ -13,6 +13,7 @@ import 'package:aewallet/ui/views/main/account_tab.dart';
 import 'package:aewallet/ui/views/main/address_book_tab.dart';
 import 'package:aewallet/ui/views/main/components/main_appbar.dart';
 import 'package:aewallet/ui/views/main/components/main_bottombar.dart';
+import 'package:aewallet/ui/views/main/components/recovery_phrase_banner.dart';
 import 'package:aewallet/ui/views/main/keychain_tab.dart';
 import 'package:aewallet/ui/views/main/nft_tab.dart';
 import 'package:aewallet/ui/views/messenger/layouts/messenger_tab.dart';
@@ -95,7 +96,13 @@ class _HomePageState extends ConsumerState<HomePage>
           children: const [
             AddressBookTab(),
             KeychainTab(),
-            AccountTab(),
+            Stack(
+              alignment: Alignment.bottomCenter,
+              children: [
+                AccountTab(),
+                RecoveryPhraseBanner(),
+              ],
+            ),
             NFTTab(
               key: Key('bottomBarAddressNFTlink'),
             ),

--- a/lib/ui/views/settings/backupseed_sheet.dart
+++ b/lib/ui/views/settings/backupseed_sheet.dart
@@ -1,10 +1,16 @@
 /// SPDX-License-Identifier: AGPL-3.0-or-later
+import 'package:aewallet/application/recovery_phrase_saved.dart';
 import 'package:aewallet/application/settings/theme.dart';
+import 'package:aewallet/ui/util/dimens.dart';
 import 'package:aewallet/ui/util/styles.dart';
+import 'package:aewallet/ui/views/intro/intro_backup_confirm.dart';
 import 'package:aewallet/ui/views/settings/mnemonic_display.dart';
+import 'package:aewallet/ui/widgets/components/app_button_tiny.dart';
 import 'package:aewallet/ui/widgets/components/scrollbar.dart';
 import 'package:aewallet/ui/widgets/components/sheet_header.dart';
+import 'package:aewallet/ui/widgets/components/sheet_util.dart';
 import 'package:aewallet/ui/widgets/components/tap_outside_unfocus.dart';
+import 'package:aewallet/util/mnemonics.dart';
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/localizations.dart';
@@ -19,6 +25,8 @@ class AppSeedBackupSheet extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final localizations = AppLocalizations.of(context)!;
     final theme = ref.watch(ThemeProviders.selectedTheme);
+    final recoveryPhraseSavedAsync =
+        ref.watch(RecoveryPhraseSavedProvider.isRecoveryPhraseSaved);
 
     return TapOutsideUnfocus(
       child: LayoutBuilder(
@@ -112,6 +120,37 @@ class AppSeedBackupSheet extends ConsumerWidget {
                           ],
                         ),
                       ),
+                    ),
+                    recoveryPhraseSavedAsync.map(
+                      data: (data) => data.value == false
+                          ? Row(
+                              children: <Widget>[
+                                AppButtonTinyConnectivity(
+                                  localizations.recoveryPhraseSave,
+                                  icon: Icons.note_add,
+                                  Dimens.buttonBottomDimens,
+                                  key: const Key('saveRecoveryPhrase'),
+                                  onPressed: () async {
+                                    final seed =
+                                        AppMnemomics.mnemonicListToSeed(
+                                      mnemonic!,
+                                    );
+                                    Sheets.showAppHeightNineSheet(
+                                      context: context,
+                                      ref: ref,
+                                      widget: IntroBackupConfirm(
+                                        name: null,
+                                        seed: seed,
+                                        welcomeProcess: false,
+                                      ),
+                                    );
+                                  },
+                                ),
+                              ],
+                            )
+                          : const SizedBox(),
+                      error: (error) => const SizedBox(),
+                      loading: (loading) => const SizedBox(),
                     ),
                   ],
                 ),


### PR DESCRIPTION
# Description

Fixes #777 

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)

## Material used:

Please delete options that are not relevant.
- iOS (Mac)

## How Has This Been Tested?

1) Creation of a new wallet with pass process when we should validate the secret phrase
The banner is correctly on the main screen
If we click on this banner, the secret phrase sheet appears (after authentification process)
The button to save phrase is displayed
When we click on this button, the confirmation sheet appears and after filling all words and validate, the banner and the "save" button disappear correctly.

2) When we recover a wallet from the recovery phrase, no banner and no save button -> ok

3) Creation of a new wallet without pass process, no banner and no save button -> ok

4) If we choose mainnet in the creation process, the pass button is available -> ok

## Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

## Useful info for the reviewer:
