### PR TITLE
UI fix for messaging screens

### DIFF
--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -539,7 +539,7 @@
   "serviceName": "Name :",
   "signTransactionListTransactionsHeader": "Transaction %1",
   "messengerTalkNotFound": "Messaging group not found",
-  "messengerHeader": "Messenger",
+  "messengerHeader": "Discussions",
   "addMessengerGroup": "Create a messaging group",
   "addRemoteMessengerGroup": "Add this messaging group",
   "addMessengerTalk": "Create a talk group",
@@ -557,5 +557,5 @@
       }
     }
   },
-  "searchDiscussionHint": "Search for a discussion\nfrom an address."
+  "searchDiscussionHint": "Search from an address"
 }

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -516,7 +516,7 @@
 	"serviceName": "Name :",
 	"signTransactionListTransactionsHeader": "Transaction %1",
 	"messengerTalkNotFound": "Discussion introuvable",
-	"messengerHeader": "Messages",
+	"messengerHeader": "Discussions",
 	"addMessengerGroup": "Créer une discussion",
 	"addRemoteMessengerGroup": "Ajouter cette discussion",
 	"addMessengerTalk": "Créer une conversation",
@@ -524,7 +524,7 @@
 	"introNewMessengerTalk": "Choisissez le nom à donner à ce groupe, ainsi que les personnes à y inviter",
 	"messengerTalkAccessDescription": "Ajoutez ou supprimez des clés publiques pouvant accéder à cette conversation.",
 	"messengerTalkAddAccess": "Ajouter un accès",
-	"addMessengerTalkFailure": "La création à échouée",
+	"addMessengerTalkFailure": "La création a échoué",
 	"messengerTalkMembersCount": "{membersCount} membres",
 	"@messengerTalkMembersCount": {
 		"placeholders": {
@@ -534,5 +534,5 @@
 			}
 		}
 	},
-	"searchDiscussionHint": "Rechercher une discussion\nà partir d'une adresse."
+	"searchDiscussionHint": "Rechercher à partir d'une adresse"
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -203,115 +203,125 @@ class AppState extends ConsumerState<App> with WidgetsBindingObserver {
     SystemChrome.setSystemUIOverlayStyle(
       theme.statusBar!,
     );
-    return OKToast(
-      textStyle: theme.textStyleSize14W700Background,
-      backgroundColor: theme.background,
-      child: MaterialApp(
-        navigatorKey: rootNavigatorKey,
-        debugShowCheckedModeBanner: false,
-        title: 'Archethic Wallet',
-        theme: ThemeData(
-          dialogBackgroundColor: theme.backgroundDark,
-          primaryColor: theme.text,
-          fontFamily: theme.secondaryFont,
-          brightness: theme.brightness,
-        ),
-        localizationsDelegates: const [
-          AppLocalizations.delegate,
-          GlobalMaterialLocalizations.delegate,
-          GlobalCupertinoLocalizations.delegate,
-          GlobalWidgetsLocalizations.delegate,
-        ],
-        locale: language.getLocale(),
-        supportedLocales: ref.read(LanguageProviders.availableLocales),
-        initialRoute: '/',
-        onGenerateRoute: (RouteSettings settings) {
-          if (deeplinkRpcReceiver.canHandle(settings.name)) {
-            deeplinkRpcReceiver.handle(settings.name);
-            return null;
-          }
-
-          final routes = <String, MaterialPageRoute>{
-            '/': NoTransitionRoute<Splash>(
-              builder: (_) => const Splash(),
-              settings: settings,
-            ),
-            '/home': NoTransitionRoute<HomePage>(
-              builder: (_) => const AutoLockGuard(child: HomePage()),
-              settings: settings,
-            ),
-            '/intro_welcome': NoTransitionRoute<IntroWelcome>(
-              builder: (_) => const IntroWelcome(),
-              settings: settings,
-            ),
-            '/intro_welcome_get_first_infos':
-                MaterialPageRoute<IntroNewWalletGetFirstInfos>(
-              builder: (_) => const IntroNewWalletGetFirstInfos(),
-              settings: settings,
-            ),
-            '/intro_backup': MaterialPageRoute<IntroBackupSeedPage>(
-              builder: (_) => IntroBackupSeedPage(
-                name: settings.arguments as String?,
-              ),
-              settings: settings,
-            ),
-            '/intro_backup_safety': MaterialPageRoute<IntroNewWalletDisclaimer>(
-              builder: (_) => IntroNewWalletDisclaimer(
-                name: settings.arguments as String?,
-              ),
-              settings: settings,
-            ),
-            '/intro_import': MaterialPageRoute<IntroImportSeedPage>(
-              builder: (_) => const IntroImportSeedPage(),
-              settings: settings,
-            ),
-            '/intro_backup_confirm': MaterialPageRoute<IntroBackupConfirm>(
-              builder: (_) {
-                final args = settings.arguments as Map<String, dynamic>? ?? {};
-                return IntroBackupConfirm(
-                  name: args['name'] == null ? null : args['name'] as String,
-                  seed: args['seed'] == null ? null : args['seed'] as String,
-                );
-              },
-              settings: settings,
-            ),
-            '/lock_screen_transition': MaterialPageRoute<AppLockScreen>(
-              builder: (_) => const AppLockScreen(),
-              settings: settings,
-            ),
-            '/nft_list_per_category': MaterialPageRoute<NFTListPerCategory>(
-              builder: (_) => NFTListPerCategory(
-                currentNftCategoryIndex: settings.arguments as int?,
-              ),
-              settings: settings,
-            ),
-            '/nft_creation': MaterialPageRoute(
-              builder: (_) {
-                final args = settings.arguments as Map<String, dynamic>? ?? {};
-                return NftCreationProcessSheet(
-                  currentNftCategoryIndex:
-                      args['currentNftCategoryIndex'] as int,
-                );
-              },
-              settings: settings,
-            ),
-            '/messenger_talk': MaterialPageRoute(
-              builder: (_) =>
-                  MessengerTalkPage(talkAddress: settings.arguments! as String),
-            ),
-          };
-
-          /// Wraps all routes with [RPCCommandReceiver]
-          /// That way, RPCCommandReceiver should never been disposed.
-          final route = routes[settings.name];
-          return route?.copyWith(
-            builder: (context) => RPCCommandReceiver(
-              child: route.builder(context),
-            ),
-          );
+    return GestureDetector(
+        onTap: () {
+          // Hide soft input keyboard after tapping outside anywhere on screen
+          FocusScope.of(context).requestFocus(FocusNode());
         },
-      ),
-    );
+        child: OKToast(
+          textStyle: theme.textStyleSize14W700Background,
+          backgroundColor: theme.background,
+          child: MaterialApp(
+            navigatorKey: rootNavigatorKey,
+            debugShowCheckedModeBanner: false,
+            title: 'Archethic Wallet',
+            theme: ThemeData(
+              dialogBackgroundColor: theme.backgroundDark,
+              primaryColor: theme.text,
+              fontFamily: theme.secondaryFont,
+              brightness: theme.brightness,
+            ),
+            localizationsDelegates: const [
+              AppLocalizations.delegate,
+              GlobalMaterialLocalizations.delegate,
+              GlobalCupertinoLocalizations.delegate,
+              GlobalWidgetsLocalizations.delegate,
+            ],
+            locale: language.getLocale(),
+            supportedLocales: ref.read(LanguageProviders.availableLocales),
+            initialRoute: '/',
+            onGenerateRoute: (RouteSettings settings) {
+              if (deeplinkRpcReceiver.canHandle(settings.name)) {
+                deeplinkRpcReceiver.handle(settings.name);
+                return null;
+              }
+
+              final routes = <String, MaterialPageRoute>{
+                '/': NoTransitionRoute<Splash>(
+                  builder: (_) => const Splash(),
+                  settings: settings,
+                ),
+                '/home': NoTransitionRoute<HomePage>(
+                  builder: (_) => const AutoLockGuard(child: HomePage()),
+                  settings: settings,
+                ),
+                '/intro_welcome': NoTransitionRoute<IntroWelcome>(
+                  builder: (_) => const IntroWelcome(),
+                  settings: settings,
+                ),
+                '/intro_welcome_get_first_infos':
+                    MaterialPageRoute<IntroNewWalletGetFirstInfos>(
+                  builder: (_) => const IntroNewWalletGetFirstInfos(),
+                  settings: settings,
+                ),
+                '/intro_backup': MaterialPageRoute<IntroBackupSeedPage>(
+                  builder: (_) => IntroBackupSeedPage(
+                    name: settings.arguments as String?,
+                  ),
+                  settings: settings,
+                ),
+                '/intro_backup_safety':
+                    MaterialPageRoute<IntroNewWalletDisclaimer>(
+                  builder: (_) => IntroNewWalletDisclaimer(
+                    name: settings.arguments as String?,
+                  ),
+                  settings: settings,
+                ),
+                '/intro_import': MaterialPageRoute<IntroImportSeedPage>(
+                  builder: (_) => const IntroImportSeedPage(),
+                  settings: settings,
+                ),
+                '/intro_backup_confirm': MaterialPageRoute<IntroBackupConfirm>(
+                  builder: (_) {
+                    final args =
+                        settings.arguments as Map<String, dynamic>? ?? {};
+                    return IntroBackupConfirm(
+                      name:
+                          args['name'] == null ? null : args['name'] as String,
+                      seed:
+                          args['seed'] == null ? null : args['seed'] as String,
+                    );
+                  },
+                  settings: settings,
+                ),
+                '/lock_screen_transition': MaterialPageRoute<AppLockScreen>(
+                  builder: (_) => const AppLockScreen(),
+                  settings: settings,
+                ),
+                '/nft_list_per_category': MaterialPageRoute<NFTListPerCategory>(
+                  builder: (_) => NFTListPerCategory(
+                    currentNftCategoryIndex: settings.arguments as int?,
+                  ),
+                  settings: settings,
+                ),
+                '/nft_creation': MaterialPageRoute(
+                  builder: (_) {
+                    final args =
+                        settings.arguments as Map<String, dynamic>? ?? {};
+                    return NftCreationProcessSheet(
+                      currentNftCategoryIndex:
+                          args['currentNftCategoryIndex'] as int,
+                    );
+                  },
+                  settings: settings,
+                ),
+                '/messenger_talk': MaterialPageRoute(
+                  builder: (_) => MessengerTalkPage(
+                      talkAddress: settings.arguments! as String),
+                ),
+              };
+
+              /// Wraps all routes with [RPCCommandReceiver]
+              /// That way, RPCCommandReceiver should never been disposed.
+              final route = routes[settings.name];
+              return route?.copyWith(
+                builder: (context) => RPCCommandReceiver(
+                  child: route.builder(context),
+                ),
+              );
+            },
+          ),
+        ));
   }
 }
 

--- a/lib/ui/views/main/components/main_appbar.dart
+++ b/lib/ui/views/main/components/main_appbar.dart
@@ -10,6 +10,7 @@ import 'package:aewallet/application/settings/theme.dart';
 import 'package:aewallet/application/wallet/wallet.dart';
 import 'package:aewallet/ui/util/styles.dart';
 import 'package:aewallet/ui/util/ui_util.dart';
+import 'package:aewallet/ui/views/messenger/layouts/create_talk_sheet.dart';
 import 'package:aewallet/ui/views/nft/layouts/configure_category_list.dart';
 import 'package:aewallet/ui/widgets/components/icon_network_warning.dart';
 import 'package:aewallet/ui/widgets/components/icons.dart';
@@ -79,6 +80,21 @@ class MainAppBar extends ConsumerWidget implements PreferredSizeWidget {
                       widget: const ConfigureCategoryList(),
                       onDisposed: () => ref
                           .invalidate(NftCategoryProviders.fetchNftCategories),
+                    );
+                  },
+                ),
+              if (preferences.mainScreenCurrentPage == 4)
+                IconButton(
+                  icon: const Icon(Iconsax.edit),
+                  onPressed: () async {
+                    sl.get<HapticUtil>().feedback(
+                          FeedbackType.light,
+                          preferences.activeVibrations,
+                        );
+                    Sheets.showAppHeightNineSheet(
+                      context: context,
+                      ref: ref,
+                      widget: const CreateTalkSheet(),
                     );
                   },
                 )

--- a/lib/ui/views/messenger/bloc/talk_messages.dart
+++ b/lib/ui/views/messenger/bloc/talk_messages.dart
@@ -169,7 +169,7 @@ class _PaginatedTalkMessagesNotifier extends _$PaginatedTalkMessagesNotifier {
         );
       }
 
-      if (offset == 0) {
+      if (offset == 0 && nextPageItems.isNotEmpty) {
         await _updateTalkLastMessage(nextPageItems.first);
       }
     });

--- a/lib/ui/views/messenger/layouts/components/discussion_search_bar.dart
+++ b/lib/ui/views/messenger/layouts/components/discussion_search_bar.dart
@@ -195,6 +195,8 @@ class _DiscussionSearchBarState extends ConsumerState<DiscussionSearchBar> {
           textAlign: TextAlign.center,
           controller: searchController,
           autocorrect: false,
+          maxLines:
+              null, // max number of lines cannot be set because small devices (such as iPhone SE) cannot display 68 characters in 2 lines
           textInputAction: TextInputAction.search,
           cursorColor: theme.text,
           inputFormatters: <TextInputFormatter>[

--- a/lib/ui/views/messenger/layouts/components/talk_list_item.dart
+++ b/lib/ui/views/messenger/layouts/components/talk_list_item.dart
@@ -104,7 +104,7 @@ class _LoadedTalkListItem extends TalkListItem {
       child: InkWell(
         onTap: onTap,
         child: Container(
-          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 10),
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
@@ -118,11 +118,17 @@ class _LoadedTalkListItem extends TalkListItem {
                       style: theme.textStyleSize12W600Primary,
                     ),
                   ),
+                  const SizedBox(
+                    width: 8,
+                  ),
                   Text(
                     talk.updateDate.format(context),
-                    style: theme.textStyleSize10W100Primary,
+                    style: theme.textStyleSize12W100Primary,
                   ),
                 ],
+              ),
+              const SizedBox(
+                height: 4,
               ),
               if (talk.lastMessage != null)
                 Padding(
@@ -165,7 +171,9 @@ class _LastMessagePreview extends ConsumerWidget {
       text: TextSpan(
         children: <TextSpan>[
           TextSpan(
-            text: '${contactName?.substring(1)} : ',
+            text: (contactName?.startsWith('@') ?? false)
+                ? '${contactName?.substring(1)} : '
+                : '$contactName : ',
             style: theme.textStyleSize10W600Primary,
           ),
           TextSpan(

--- a/lib/ui/views/messenger/layouts/messenger_tab.dart
+++ b/lib/ui/views/messenger/layouts/messenger_tab.dart
@@ -1,14 +1,9 @@
 import 'package:aewallet/application/settings/theme.dart';
-import 'package:aewallet/ui/util/dimens.dart';
 import 'package:aewallet/ui/views/messenger/bloc/providers.dart';
 import 'package:aewallet/ui/views/messenger/layouts/components/discussion_search_bar.dart';
 import 'package:aewallet/ui/views/messenger/layouts/components/talk_list_item.dart';
-import 'package:aewallet/ui/views/messenger/layouts/create_talk_sheet.dart';
-import 'package:aewallet/ui/widgets/components/app_button_tiny.dart';
-import 'package:aewallet/ui/widgets/components/sheet_util.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
-import 'package:flutter_gen/gen_l10n/localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 class MessengerTab extends ConsumerWidget {
@@ -29,7 +24,6 @@ class MessengerBody extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     MessengerProviders.subscribeNotificationsWorker(ref);
     final asyncTalks = ref.watch(MessengerProviders.sortedTalks);
-    final localizations = AppLocalizations.of(context)!;
     final theme = ref.watch(ThemeProviders.selectedTheme);
 
     return DecoratedBox(
@@ -85,28 +79,6 @@ class MessengerBody extends ConsumerWidget {
                     },
                   ),
                 ),
-              ),
-              Row(
-                children: [
-                  AppButtonTiny(
-                    AppButtonTinyType.primary,
-                    localizations.addMessengerGroup,
-                    Dimens.buttonBottomDimens,
-                    key: const Key('addMessengerGroup'),
-                    icon: Icon(
-                      Icons.add,
-                      color: theme.mainButtonLabel,
-                      size: 14,
-                    ),
-                    onPressed: () async {
-                      Sheets.showAppHeightNineSheet(
-                        context: context,
-                        ref: ref,
-                        widget: const CreateTalkSheet(),
-                      );
-                    },
-                  ),
-                ],
               ),
             ],
           ),

--- a/lib/ui/views/messenger/layouts/messenger_talk_page.dart
+++ b/lib/ui/views/messenger/layouts/messenger_talk_page.dart
@@ -15,6 +15,7 @@ import 'package:aewallet/util/date_util.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:iconsax/iconsax.dart';
 import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
 import 'package:loading_animation_widget/loading_animation_widget.dart';
 
@@ -50,22 +51,25 @@ class MessengerTalkPage extends ConsumerWidget {
         appBar: AppBar(
           backgroundColor: Colors.transparent,
           elevation: 0,
+          actions: [
+            IconButton(
+              icon: const Icon(Iconsax.info_circle),
+              onPressed: () async {
+                Sheets.showAppHeightNineSheet(
+                  context: context,
+                  ref: ref,
+                  widget: TalkDetailsSheet(talkAddress: talkAddress),
+                );
+              },
+            ),
+          ],
           title: talk.maybeMap(
             data: (data) {
               final displayName = ref.watch(
                 MessengerProviders.talkDisplayName(data.value),
               );
 
-              return InkWell(
-                onTap: () {
-                  Sheets.showAppHeightNineSheet(
-                    context: context,
-                    ref: ref,
-                    widget: TalkDetailsSheet(talkAddress: talkAddress),
-                  );
-                },
-                child: Text(displayName),
-              );
+              return Text(displayName);
             },
             orElse: () => const Text('           ')
                 .animate(
@@ -111,9 +115,14 @@ class __MessageSendFormState extends ConsumerState<_MessageSendForm> {
 
   @override
   void initState() {
+    super.initState();
+
     textEditingController = TextEditingController();
     messageFocusNode = FocusNode();
-    super.initState();
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      messageFocusNode.requestFocus();
+    });
   }
 
   @override
@@ -190,7 +199,6 @@ class __MessageSendFormState extends ConsumerState<_MessageSendForm> {
                                 ),
                               )
                               .text;
-                          messageFocusNode.requestFocus();
                         },
                   icon: Icon(
                     Icons.send,
@@ -226,7 +234,6 @@ class _MessageTextField extends ConsumerWidget {
     return Stack(
       children: [
         TextField(
-          autofocus: true,
           maxLines: null,
           controller: textEditingController,
           focusNode: focusNode,

--- a/lib/util/date_util.dart
+++ b/lib/util/date_util.dart
@@ -17,7 +17,7 @@ extension DurationUtil on Duration {
 extension FormatDateTimeDependingDays on DateTime {
   String format(BuildContext context) {
     if (difference(DateTime.now()).inDays < 1) {
-      return DateFormat().add_Hms().format(this);
+      return DateFormat().add_Hm().format(this);
     } else {
       if (difference(DateTime.now()).inDays < 30) {
         return DateFormat.MEd(


### PR DESCRIPTION
# Description

UI/UX Improvements for the messaging screens

Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

- Hide the keyboard when the user taps outside a tapping area
- Update localizations
- Delete the create talk button from messenger tab and add it into the app bar
- Handling no items into talks
- UI improvements in discussion screen
- More space into the discussion list item
- Add an info icon in the talk page
- The dates displayed in the discussions page are now only showing hour and minute, no seconds anymore

## Material used:

- iOS : iPhone SE 2020, iPhone 14 Pro Max

## How Has This Been Tested?

Tested directly from the simulators

### Patrol

-

## Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

## Useful info for the reviewer:

- If you don't want to have too many injuries, run slower.