### PR TITLE
Better management for disabled main button

### DIFF
--- a/lib/ui/views/messenger/layouts/create_talk_sheet.dart
+++ b/lib/ui/views/messenger/layouts/create_talk_sheet.dart
@@ -117,52 +117,48 @@ class CreateTalkSheet extends ConsumerWidget {
                 ),
               ),
             ),
-            Column(
+            Row(
               children: <Widget>[
-                Row(
-                  children: <Widget>[
-                    AppButtonTiny(
-                      AppButtonTinyType.primary,
-                      localizations.addMessengerTalk,
-                      Dimens.buttonBottomDimens,
-                      key: const Key('addMessengerTalk'),
-                      icon: Icon(
-                        Icons.add,
-                        color: formState.canSubmit
-                            ? theme.mainButtonLabel
-                            : theme
-                                .textStyleSize18W600EquinoxMainButtonLabelDisabled
-                                .color,
-                        size: 14,
-                      ),
-                      disabled: formState.canSubmit == false,
-                      onPressed: () async {
-                        ShowSendingAnimation.build(
-                          context,
-                          theme,
-                        );
-                        final result = await formNotifier.createTalk();
-                        Navigator.of(context).pop();
+                AppButtonTiny(
+                  AppButtonTinyType.primary,
+                  localizations.addMessengerTalk,
+                  Dimens.buttonBottomDimens,
+                  key: const Key('addMessengerTalk'),
+                  icon: Icon(
+                    Icons.add,
+                    color: formState.canSubmit
+                        ? theme.mainButtonLabel
+                        : theme
+                            .textStyleSize18W600EquinoxMainButtonLabelDisabled
+                            .color,
+                    size: 14,
+                  ),
+                  disabled: formState.canSubmit == false,
+                  onPressed: () async {
+                    ShowSendingAnimation.build(
+                      context,
+                      theme,
+                    );
+                    final result = await formNotifier.createTalk();
+                    Navigator.of(context).pop();
 
-                        result.map(
-                          success: (success) {
-                            Navigator.of(context).pop();
-                          },
-                          failure: (failure) {
-                            UIUtil.showSnackbar(
-                              localizations.addMessengerTalkFailure,
-                              context,
-                              ref,
-                              theme.text!,
-                              theme.snackBarShadow!,
-                              duration: const Duration(seconds: 5),
-                            );
-                          },
+                    result.map(
+                      success: (success) {
+                        Navigator.of(context).pop();
+                      },
+                      failure: (failure) {
+                        UIUtil.showSnackbar(
+                          localizations.addMessengerTalkFailure,
+                          context,
+                          ref,
+                          theme.text!,
+                          theme.snackBarShadow!,
+                          duration: const Duration(seconds: 5),
                         );
                       },
-                    )
-                  ],
-                ),
+                    );
+                  },
+                )
               ],
             ),
           ],

--- a/lib/ui/views/messenger/layouts/create_talk_sheet.dart
+++ b/lib/ui/views/messenger/layouts/create_talk_sheet.dart
@@ -121,55 +121,46 @@ class CreateTalkSheet extends ConsumerWidget {
               children: <Widget>[
                 Row(
                   children: <Widget>[
-                    if (formState.canSubmit)
-                      AppButtonTiny(
-                        AppButtonTinyType.primary,
-                        localizations.addMessengerTalk,
-                        Dimens.buttonBottomDimens,
-                        key: const Key('addMessengerTalk'),
-                        icon: Icon(
-                          Icons.add,
-                          color: theme.mainButtonLabel,
-                          size: 14,
-                        ),
-                        onPressed: () async {
-                          ShowSendingAnimation.build(
-                            context,
-                            theme,
-                          );
-                          final result = await formNotifier.createTalk();
-                          Navigator.of(context).pop();
-
-                          result.map(
-                            success: (success) {
-                              Navigator.of(context).pop();
-                            },
-                            failure: (failure) {
-                              UIUtil.showSnackbar(
-                                localizations.addMessengerTalkFailure,
-                                context,
-                                ref,
-                                theme.text!,
-                                theme.snackBarShadow!,
-                                duration: const Duration(seconds: 5),
-                              );
-                            },
-                          );
-                        },
-                      )
-                    else
-                      AppButtonTiny(
-                        AppButtonTinyType.primaryOutline,
-                        localizations.addMessengerTalk,
-                        Dimens.buttonBottomDimens,
-                        key: const Key('addMessengerTalk'),
-                        icon: Icon(
-                          Icons.add,
-                          color: theme.mainButtonLabel!.withOpacity(0.3),
-                          size: 14,
-                        ),
-                        onPressed: () {},
+                    AppButtonTiny(
+                      AppButtonTinyType.primary,
+                      localizations.addMessengerTalk,
+                      Dimens.buttonBottomDimens,
+                      key: const Key('addMessengerTalk'),
+                      icon: Icon(
+                        Icons.add,
+                        color: formState.canSubmit
+                            ? theme.mainButtonLabel
+                            : theme
+                                .textStyleSize18W600EquinoxMainButtonLabelDisabled
+                                .color,
+                        size: 14,
                       ),
+                      disabled: formState.canSubmit == false,
+                      onPressed: () async {
+                        ShowSendingAnimation.build(
+                          context,
+                          theme,
+                        );
+                        final result = await formNotifier.createTalk();
+                        Navigator.of(context).pop();
+
+                        result.map(
+                          success: (success) {
+                            Navigator.of(context).pop();
+                          },
+                          failure: (failure) {
+                            UIUtil.showSnackbar(
+                              localizations.addMessengerTalkFailure,
+                              context,
+                              ref,
+                              theme.text!,
+                              theme.snackBarShadow!,
+                              duration: const Duration(seconds: 5),
+                            );
+                          },
+                        );
+                      },
+                    )
                   ],
                 ),
               ],

--- a/lib/ui/widgets/components/app_button_tiny.dart
+++ b/lib/ui/widgets/components/app_button_tiny.dart
@@ -175,11 +175,11 @@ class AppButtonTinyWithoutExpanded extends ConsumerWidget {
               ? _NoIconButton(
                   showProgressIndicator: showProgressIndicator,
                   buttonText: buttonText,
-                  onPressed: handlePressed,
+                  onPressed: disabled == true ? null : handlePressed,
                 )
               : _IconButton(
                   buttonText: buttonText,
-                  onPressed: handlePressed,
+                  onPressed: disabled == true ? null : handlePressed,
                   icon: icon,
                   showProgressIndicator: showProgressIndicator,
                 ),
@@ -202,11 +202,11 @@ class AppButtonTinyWithoutExpanded extends ConsumerWidget {
               ? _NoIconButton(
                   showProgressIndicator: showProgressIndicator,
                   buttonText: buttonText,
-                  onPressed: handlePressed,
+                  onPressed: disabled == true ? null : handlePressed,
                 )
               : _IconButtonOutline(
                   buttonText: buttonText,
-                  onPressed: handlePressed,
+                  onPressed: disabled == true ? null : handlePressed,
                   icon: icon,
                 ),
         );
@@ -300,7 +300,10 @@ class _IconButton extends ConsumerWidget {
               child: SizedBox.square(
                 dimension: 8,
                 child: CircularProgressIndicator(
-                  color: theme.textStyleSize12W400EquinoxMainButtonLabel.color,
+                  color: onPressed == null
+                      ? theme.textStyleSize18W600EquinoxMainButtonLabelDisabled
+                          .color
+                      : theme.textStyleSize12W400EquinoxMainButtonLabel.color,
                   strokeWidth: 1,
                 ),
               ),
@@ -313,7 +316,12 @@ class _IconButton extends ConsumerWidget {
           AutoSizeText(
             buttonText,
             textAlign: TextAlign.center,
-            style: theme.textStyleSize12W400EquinoxMainButtonLabel,
+            style: theme.textStyleSize12W400EquinoxMainButtonLabel.copyWith(
+              color: onPressed == null
+                  ? theme
+                      .textStyleSize18W600EquinoxMainButtonLabelDisabled.color
+                  : theme.textStyleSize12W400EquinoxMainButtonLabel.color,
+            ),
             maxLines: 1,
             stepGranularity: 0.5,
           ),

--- a/lib/ui/widgets/components/app_button_tiny.dart
+++ b/lib/ui/widgets/components/app_button_tiny.dart
@@ -301,7 +301,7 @@ class _IconButton extends ConsumerWidget {
                 dimension: 8,
                 child: CircularProgressIndicator(
                   color: onPressed == null
-                      ? theme.textStyleSize18W600EquinoxMainButtonLabelDisabled
+                      ? theme.textStyleSize12W400EquinoxMainButtonLabelDisabled
                           .color
                       : theme.textStyleSize12W400EquinoxMainButtonLabel.color,
                   strokeWidth: 1,
@@ -319,7 +319,7 @@ class _IconButton extends ConsumerWidget {
             style: theme.textStyleSize12W400EquinoxMainButtonLabel.copyWith(
               color: onPressed == null
                   ? theme
-                      .textStyleSize18W600EquinoxMainButtonLabelDisabled.color
+                      .textStyleSize12W400EquinoxMainButtonLabelDisabled.color
                   : theme.textStyleSize12W400EquinoxMainButtonLabel.color,
             ),
             maxLines: 1,


### PR DESCRIPTION
# Description

The disable property of AppButtonTiny is not used as it has to, this results in increased complexity to manage the enabling or disabling of the button.

Fixes

## Type of change

- New feature (non-breaking change which adds functionality)

## Material used:

- iOS (Smartphone/Tablet)

## How Has This Been Tested?

From the add a talk screen, we have a button "create a talk" that can be enabled or disabled wether or not the conditions are ok (fill a name and add at least one contact).

Previously, we had to have a column with a row with two buttons (one enabled and the other other disabled) => this can be simplified by the use of the correct disabled property, we now have only one button with two states (disable or not) that can handle both cases. We don't need the second button anymore.

### Patrol

Please list here the tests created in Patrol for this pull request.

## Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

## Useful info for the reviewer:
