### PR TITLE
Create single contact discussion

### DIFF
--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -540,7 +540,8 @@
   "signTransactionListTransactionsHeader": "Transaction %1",
   "messengerTalkNotFound": "Messaging group not found",
   "messengerHeader": "Discussions",
-  "newTalk": "New discussion",
+  "newDiscussion": "New discussion",
+  "createDiscussion": "Create a discussion",
   "newGroup": "New group",
   "addRemoteMessengerGroup": "Add this messaging group",
   "createGroup": "Create a group",
@@ -565,5 +566,6 @@
   "recoveryPhraseSave": "Save secret phrase",
   "newContact": "New contact",
   "contactsHeader": "Contacts",
-  "noContacts" : "You have no contacts"
+  "noContacts" : "You have no contacts",
+  "aboutToCreateADiscussion": "You are about to create a discussion with"
 }

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -517,7 +517,8 @@
 	"signTransactionListTransactionsHeader": "Transaction %1",
 	"messengerTalkNotFound": "Discussion introuvable",
 	"messengerHeader": "Discussions",
-	"newTalk": "Nouvelle discussion",
+	"newDiscussion": "Nouvelle discussion",
+	"createDiscussion": "Créer une discussion",
 	"newGroup": "Nouveau groupe",
 	"addRemoteMessengerGroup": "Ajouter cette discussion",
 	"createGroup": "Créer un groupe",
@@ -542,5 +543,6 @@
 	"recoveryPhraseSave": "Sauvegarder la phrase secrète",
 	"newContact": "Nouveau contact",
 	"contactsHeader": "Contacts",
-	"noContacts" : "Vous n'avez aucun contact"
+	"noContacts" : "Vous n'avez aucun contact",
+	"aboutToCreateADiscussion": "Vous êtes sur le point de créer une discussion avec"
 }

--- a/lib/model/data/contact.dart
+++ b/lib/model/data/contact.dart
@@ -38,11 +38,4 @@ class Contact extends HiveObject {
   /// Favorite
   @HiveField(6)
   bool? favorite;
-
-  String get displayName {
-    if (name.startsWith('@')) {
-      return name.substring(1);
-    }
-    return name;
-  }
 }

--- a/lib/model/data/contact.dart
+++ b/lib/model/data/contact.dart
@@ -38,4 +38,11 @@ class Contact extends HiveObject {
   /// Favorite
   @HiveField(6)
   bool? favorite;
+
+  String get displayName {
+    if (name.startsWith('@')) {
+      return name.substring(1);
+    }
+    return name;
+  }
 }

--- a/lib/ui/views/contacts/layouts/contact_detail.dart
+++ b/lib/ui/views/contacts/layouts/contact_detail.dart
@@ -24,10 +24,12 @@ import 'package:flutter_vibrate/flutter_vibrate.dart';
 class ContactDetail extends ConsumerWidget {
   const ContactDetail({
     required this.contact,
+    this.editMode = true,
     super.key,
   });
 
   final Contact contact;
+  final bool editMode;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -57,7 +59,8 @@ class ContactDetail extends ConsumerWidget {
                   top: 10,
                   start: 10,
                 ),
-                child: contact.type == ContactType.keychainService.name
+                child: contact.type == ContactType.keychainService.name ||
+                        editMode == false
                     ? const SizedBox()
                     : TextButton(
                         onPressed: () {
@@ -125,7 +128,7 @@ class ContactDetail extends ConsumerWidget {
                   ],
                 ),
               ),
-              if (contact.type == ContactType.keychainService.name)
+              if (contact.type == ContactType.keychainService.name || editMode == false)
                 const SizedBox(
                   width: 50,
                   height: 50,

--- a/lib/ui/views/messenger/bloc/create_talk_contact_form.dart
+++ b/lib/ui/views/messenger/bloc/create_talk_contact_form.dart
@@ -1,65 +1,36 @@
 part of 'providers.dart';
 
-final _createTalkFormProvider =
-    NotifierProvider.autoDispose<CreateTalkFormNotifier, CreateTalkFormState>(
+final _createTalkContactFormProvider = NotifierProvider.autoDispose<
+    CreateTalkContactFormNotifier, CreateTalkContactFormState>(
   () {
-    return CreateTalkFormNotifier();
+    return CreateTalkContactFormNotifier();
   },
 );
 
 @freezed
-class CreateTalkFormState with _$CreateTalkFormState {
-  const factory CreateTalkFormState({
+class CreateTalkContactFormState with _$CreateTalkContactFormState {
+  const factory CreateTalkContactFormState({
     required String name,
-    AccessRecipient? memberAddFieldValue,
     required List<AccessRecipient> members,
-    AccessRecipient? adminAddFieldValue,
-    required List<AccessRecipient> admins,
-  }) = _CreateTalkFormState;
-  const CreateTalkFormState._();
-
-  bool get canSubmit => members.isNotEmpty;
+  }) = _CreateTalkContactFormState;
+  const CreateTalkContactFormState._();
 }
 
-class CreateTalkFormNotifier extends AutoDisposeNotifier<CreateTalkFormState> {
-  CreateTalkFormNotifier();
+class CreateTalkContactFormNotifier
+    extends AutoDisposeNotifier<CreateTalkContactFormState> {
+  CreateTalkContactFormNotifier();
 
   @override
-  CreateTalkFormState build() => const CreateTalkFormState(
+  CreateTalkContactFormState build() => const CreateTalkContactFormState(
         name: '',
         members: [],
-        admins: [],
       );
-
-  void setMemberAddFieldValue(AddPublicKeyTextFieldValue fieldValue) {
-    state = state.copyWith(memberAddFieldValue: fieldValue.toAccessRecipient);
-  }
 
   void addMember(AccessRecipient member) {
     if (state.members.contains(member)) return;
     state = state.copyWith(
       members: [
         ...state.members,
-        member,
-      ],
-    );
-  }
-
-  void removeMember(AccessRecipient member) {
-    state = state.copyWith(
-      members: state.members.where((element) => element != member).toList(),
-    );
-  }
-
-  void setAdminAddFieldValue(AddPublicKeyTextFieldValue fieldValue) {
-    state = state.copyWith(adminAddFieldValue: fieldValue.toAccessRecipient);
-  }
-
-  void addAdmin(AccessRecipient member) {
-    if (state.admins.contains(member)) return;
-    state = state.copyWith(
-      admins: [
-        ...state.admins,
         member,
       ],
     );
@@ -88,7 +59,6 @@ class CreateTalkFormNotifier extends AutoDisposeNotifier<CreateTalkFormState> {
 
         await ref.read(MessengerProviders._messengerRepository).createTalk(
           adminsPubKeys: [
-            ...state.admins.map((recipient) => recipient.publicKey),
             creator.publicKey,
           ],
           membersPubKeys: [

--- a/lib/ui/views/messenger/bloc/create_talk_contact_form.dart
+++ b/lib/ui/views/messenger/bloc/create_talk_contact_form.dart
@@ -10,8 +10,8 @@ final _createTalkContactFormProvider = NotifierProvider.autoDispose<
 @freezed
 class CreateTalkContactFormState with _$CreateTalkContactFormState {
   const factory CreateTalkContactFormState({
-    required String name,
-    required List<AccessRecipient> members,
+    @Default('') String name,
+    @Default([]) List<AccessRecipient> members,
   }) = _CreateTalkContactFormState;
   const CreateTalkContactFormState._();
 }
@@ -21,10 +21,7 @@ class CreateTalkContactFormNotifier
   CreateTalkContactFormNotifier();
 
   @override
-  CreateTalkContactFormState build() => const CreateTalkContactFormState(
-        name: '',
-        members: [],
-      );
+  CreateTalkContactFormState build() => const CreateTalkContactFormState();
 
   void addMember(AccessRecipient member) {
     if (state.members.contains(member)) return;

--- a/lib/ui/views/messenger/bloc/create_talk_contact_form.dart
+++ b/lib/ui/views/messenger/bloc/create_talk_contact_form.dart
@@ -36,9 +36,9 @@ class CreateTalkContactFormNotifier
     );
   }
 
-  Future<void> setName(
+  void setName(
     String name,
-  ) async {
+  ) {
     state = state.copyWith(
       name: name,
     );

--- a/lib/ui/views/messenger/bloc/create_talk_group_form.dart
+++ b/lib/ui/views/messenger/bloc/create_talk_group_form.dart
@@ -10,11 +10,11 @@ final _createTalkGroupFormProvider = NotifierProvider.autoDispose<
 @freezed
 class CreateTalkGroupFormState with _$CreateTalkGroupFormState {
   const factory CreateTalkGroupFormState({
-    required String name,
+    @Default('') String name,
     AccessRecipient? memberAddFieldValue,
-    required List<AccessRecipient> members,
+    @Default([]) List<AccessRecipient> members,
     AccessRecipient? adminAddFieldValue,
-    required List<AccessRecipient> admins,
+    @Default([]) List<AccessRecipient> admins,
   }) = _CreateTalkGroupFormState;
   const CreateTalkGroupFormState._();
 
@@ -26,11 +26,7 @@ class CreateTalkGroupFormNotifier
   CreateTalkGroupFormNotifier();
 
   @override
-  CreateTalkGroupFormState build() => const CreateTalkGroupFormState(
-        name: '',
-        members: [],
-        admins: [],
-      );
+  CreateTalkGroupFormState build() => const CreateTalkGroupFormState();
 
   void setMemberAddFieldValue(AddPublicKeyTextFieldValue fieldValue) {
     state = state.copyWith(memberAddFieldValue: fieldValue.toAccessRecipient);

--- a/lib/ui/views/messenger/bloc/create_talk_group_form.dart
+++ b/lib/ui/views/messenger/bloc/create_talk_group_form.dart
@@ -1,0 +1,106 @@
+part of 'providers.dart';
+
+final _createTalkGroupFormProvider = NotifierProvider.autoDispose<
+    CreateTalkGroupFormNotifier, CreateTalkGroupFormState>(
+  () {
+    return CreateTalkGroupFormNotifier();
+  },
+);
+
+@freezed
+class CreateTalkGroupFormState with _$CreateTalkGroupFormState {
+  const factory CreateTalkGroupFormState({
+    required String name,
+    AccessRecipient? memberAddFieldValue,
+    required List<AccessRecipient> members,
+    AccessRecipient? adminAddFieldValue,
+    required List<AccessRecipient> admins,
+  }) = _CreateTalkGroupFormState;
+  const CreateTalkGroupFormState._();
+
+  bool get canSubmit => members.isNotEmpty;
+}
+
+class CreateTalkGroupFormNotifier
+    extends AutoDisposeNotifier<CreateTalkGroupFormState> {
+  CreateTalkGroupFormNotifier();
+
+  @override
+  CreateTalkGroupFormState build() => const CreateTalkGroupFormState(
+        name: '',
+        members: [],
+        admins: [],
+      );
+
+  void setMemberAddFieldValue(AddPublicKeyTextFieldValue fieldValue) {
+    state = state.copyWith(memberAddFieldValue: fieldValue.toAccessRecipient);
+  }
+
+  void addMember(AccessRecipient member) {
+    if (state.members.contains(member)) return;
+    state = state.copyWith(
+      members: [
+        ...state.members,
+        member,
+      ],
+    );
+  }
+
+  void removeMember(AccessRecipient member) {
+    state = state.copyWith(
+      members: state.members.where((element) => element != member).toList(),
+    );
+  }
+
+  void setAdminAddFieldValue(AddPublicKeyTextFieldValue fieldValue) {
+    state = state.copyWith(adminAddFieldValue: fieldValue.toAccessRecipient);
+  }
+
+  void addAdmin(AccessRecipient member) {
+    if (state.admins.contains(member)) return;
+    state = state.copyWith(
+      admins: [
+        ...state.admins,
+        member,
+      ],
+    );
+  }
+
+  Future<void> setName(
+    String name,
+  ) async {
+    state = state.copyWith(
+      name: name,
+    );
+    return;
+  }
+
+  Future<Result<void, Failure>> createTalk() => Result.guard(() async {
+        final session = ref.read(SessionProviders.session).loggedIn;
+        if (session == null) throw const Failure.loggedOut();
+
+        final selectedAccount =
+            await ref.read(AccountProviders.selectedAccount.future);
+        if (selectedAccount == null) throw const Failure.loggedOut();
+
+        final creator = AccessRecipient.contact(
+          contact: await ref.read(ContactProviders.getSelectedContact.future),
+        );
+
+        await ref.read(MessengerProviders._messengerRepository).createTalk(
+          adminsPubKeys: [
+            ...state.admins.map((recipient) => recipient.publicKey),
+            creator.publicKey,
+          ],
+          membersPubKeys: [
+            ...state.members.map((recipient) => recipient.publicKey),
+            creator.publicKey,
+          ],
+          creator: selectedAccount,
+          session: session,
+          groupName: state.name,
+        ).valueOrThrow;
+
+        ref.invalidate(_talksProvider);
+      });
+}

--- a/lib/ui/views/messenger/bloc/providers.dart
+++ b/lib/ui/views/messenger/bloc/providers.dart
@@ -20,7 +20,8 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
-part 'create_group_form.dart';
+part 'create_talk_contact_form.dart';
+part 'create_talk_group_form.dart';
 part 'providers.freezed.dart';
 part 'providers.g.dart';
 part 'talk_messages.dart';
@@ -222,7 +223,8 @@ abstract class MessengerProviders {
   static const messages = _talkMessagesProvider;
   static const paginatedMessages = _paginatedTalkMessagesNotifierProvider;
 
-  static final talkCreationForm = _createTalkFormProvider;
+  static final talkContactCreationForm = _createTalkContactFormProvider;
+  static final talkGroupCreationForm = _createTalkGroupFormProvider;
   static const messageCreationForm = _messageCreationFormNotifierProvider;
   static const messageCreationFees = _messageCreationFeesProvider;
 
@@ -230,7 +232,8 @@ abstract class MessengerProviders {
     await ref.read(_messengerRepository).clear();
     ref
       ..invalidate(_talkProvider)
-      ..invalidate(_createTalkFormProvider)
+      ..invalidate(_createTalkContactFormProvider)
+      ..invalidate(_createTalkGroupFormProvider)
       ..invalidate(_talkMessagesProvider);
   }
 }

--- a/lib/ui/views/messenger/bloc/providers.freezed.dart
+++ b/lib/ui/views/messenger/bloc/providers.freezed.dart
@@ -109,14 +109,16 @@ class __$$_CreateTalkContactFormStateCopyWithImpl<$Res>
 
 class _$_CreateTalkContactFormState extends _CreateTalkContactFormState {
   const _$_CreateTalkContactFormState(
-      {required this.name, required final List<AccessRecipient> members})
+      {this.name = '', final List<AccessRecipient> members = const []})
       : _members = members,
         super._();
 
   @override
+  @JsonKey()
   final String name;
   final List<AccessRecipient> _members;
   @override
+  @JsonKey()
   List<AccessRecipient> get members {
     if (_members is EqualUnmodifiableListView) return _members;
     // ignore: implicit_dynamic_type
@@ -151,9 +153,8 @@ class _$_CreateTalkContactFormState extends _CreateTalkContactFormState {
 
 abstract class _CreateTalkContactFormState extends CreateTalkContactFormState {
   const factory _CreateTalkContactFormState(
-          {required final String name,
-          required final List<AccessRecipient> members}) =
-      _$_CreateTalkContactFormState;
+      {final String name,
+      final List<AccessRecipient> members}) = _$_CreateTalkContactFormState;
   const _CreateTalkContactFormState._() : super._();
 
   @override
@@ -335,21 +336,23 @@ class __$$_CreateTalkGroupFormStateCopyWithImpl<$Res>
 
 class _$_CreateTalkGroupFormState extends _CreateTalkGroupFormState {
   const _$_CreateTalkGroupFormState(
-      {required this.name,
+      {this.name = '',
       this.memberAddFieldValue,
-      required final List<AccessRecipient> members,
+      final List<AccessRecipient> members = const [],
       this.adminAddFieldValue,
-      required final List<AccessRecipient> admins})
+      final List<AccessRecipient> admins = const []})
       : _members = members,
         _admins = admins,
         super._();
 
   @override
+  @JsonKey()
   final String name;
   @override
   final AccessRecipient? memberAddFieldValue;
   final List<AccessRecipient> _members;
   @override
+  @JsonKey()
   List<AccessRecipient> get members {
     if (_members is EqualUnmodifiableListView) return _members;
     // ignore: implicit_dynamic_type
@@ -360,6 +363,7 @@ class _$_CreateTalkGroupFormState extends _CreateTalkGroupFormState {
   final AccessRecipient? adminAddFieldValue;
   final List<AccessRecipient> _admins;
   @override
+  @JsonKey()
   List<AccessRecipient> get admins {
     if (_admins is EqualUnmodifiableListView) return _admins;
     // ignore: implicit_dynamic_type
@@ -404,12 +408,11 @@ class _$_CreateTalkGroupFormState extends _CreateTalkGroupFormState {
 
 abstract class _CreateTalkGroupFormState extends CreateTalkGroupFormState {
   const factory _CreateTalkGroupFormState(
-          {required final String name,
-          final AccessRecipient? memberAddFieldValue,
-          required final List<AccessRecipient> members,
-          final AccessRecipient? adminAddFieldValue,
-          required final List<AccessRecipient> admins}) =
-      _$_CreateTalkGroupFormState;
+      {final String name,
+      final AccessRecipient? memberAddFieldValue,
+      final List<AccessRecipient> members,
+      final AccessRecipient? adminAddFieldValue,
+      final List<AccessRecipient> admins}) = _$_CreateTalkGroupFormState;
   const _CreateTalkGroupFormState._() : super._();
 
   @override

--- a/lib/ui/views/messenger/bloc/providers.freezed.dart
+++ b/lib/ui/views/messenger/bloc/providers.freezed.dart
@@ -15,7 +15,159 @@ final _privateConstructorUsedError = UnsupportedError(
     'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
 
 /// @nodoc
-mixin _$CreateTalkFormState {
+mixin _$CreateTalkContactFormState {
+  String get name => throw _privateConstructorUsedError;
+  List<AccessRecipient> get members => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $CreateTalkContactFormStateCopyWith<CreateTalkContactFormState>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $CreateTalkContactFormStateCopyWith<$Res> {
+  factory $CreateTalkContactFormStateCopyWith(CreateTalkContactFormState value,
+          $Res Function(CreateTalkContactFormState) then) =
+      _$CreateTalkContactFormStateCopyWithImpl<$Res,
+          CreateTalkContactFormState>;
+  @useResult
+  $Res call({String name, List<AccessRecipient> members});
+}
+
+/// @nodoc
+class _$CreateTalkContactFormStateCopyWithImpl<$Res,
+        $Val extends CreateTalkContactFormState>
+    implements $CreateTalkContactFormStateCopyWith<$Res> {
+  _$CreateTalkContactFormStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? name = null,
+    Object? members = null,
+  }) {
+    return _then(_value.copyWith(
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      members: null == members
+          ? _value.members
+          : members // ignore: cast_nullable_to_non_nullable
+              as List<AccessRecipient>,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$_CreateTalkContactFormStateCopyWith<$Res>
+    implements $CreateTalkContactFormStateCopyWith<$Res> {
+  factory _$$_CreateTalkContactFormStateCopyWith(
+          _$_CreateTalkContactFormState value,
+          $Res Function(_$_CreateTalkContactFormState) then) =
+      __$$_CreateTalkContactFormStateCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String name, List<AccessRecipient> members});
+}
+
+/// @nodoc
+class __$$_CreateTalkContactFormStateCopyWithImpl<$Res>
+    extends _$CreateTalkContactFormStateCopyWithImpl<$Res,
+        _$_CreateTalkContactFormState>
+    implements _$$_CreateTalkContactFormStateCopyWith<$Res> {
+  __$$_CreateTalkContactFormStateCopyWithImpl(
+      _$_CreateTalkContactFormState _value,
+      $Res Function(_$_CreateTalkContactFormState) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? name = null,
+    Object? members = null,
+  }) {
+    return _then(_$_CreateTalkContactFormState(
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      members: null == members
+          ? _value._members
+          : members // ignore: cast_nullable_to_non_nullable
+              as List<AccessRecipient>,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$_CreateTalkContactFormState extends _CreateTalkContactFormState {
+  const _$_CreateTalkContactFormState(
+      {required this.name, required final List<AccessRecipient> members})
+      : _members = members,
+        super._();
+
+  @override
+  final String name;
+  final List<AccessRecipient> _members;
+  @override
+  List<AccessRecipient> get members {
+    if (_members is EqualUnmodifiableListView) return _members;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_members);
+  }
+
+  @override
+  String toString() {
+    return 'CreateTalkContactFormState(name: $name, members: $members)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_CreateTalkContactFormState &&
+            (identical(other.name, name) || other.name == name) &&
+            const DeepCollectionEquality().equals(other._members, _members));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, name, const DeepCollectionEquality().hash(_members));
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_CreateTalkContactFormStateCopyWith<_$_CreateTalkContactFormState>
+      get copyWith => __$$_CreateTalkContactFormStateCopyWithImpl<
+          _$_CreateTalkContactFormState>(this, _$identity);
+}
+
+abstract class _CreateTalkContactFormState extends CreateTalkContactFormState {
+  const factory _CreateTalkContactFormState(
+          {required final String name,
+          required final List<AccessRecipient> members}) =
+      _$_CreateTalkContactFormState;
+  const _CreateTalkContactFormState._() : super._();
+
+  @override
+  String get name;
+  @override
+  List<AccessRecipient> get members;
+  @override
+  @JsonKey(ignore: true)
+  _$$_CreateTalkContactFormStateCopyWith<_$_CreateTalkContactFormState>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$CreateTalkGroupFormState {
   String get name => throw _privateConstructorUsedError;
   AccessRecipient? get memberAddFieldValue =>
       throw _privateConstructorUsedError;
@@ -24,15 +176,15 @@ mixin _$CreateTalkFormState {
   List<AccessRecipient> get admins => throw _privateConstructorUsedError;
 
   @JsonKey(ignore: true)
-  $CreateTalkFormStateCopyWith<CreateTalkFormState> get copyWith =>
+  $CreateTalkGroupFormStateCopyWith<CreateTalkGroupFormState> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class $CreateTalkFormStateCopyWith<$Res> {
-  factory $CreateTalkFormStateCopyWith(
-          CreateTalkFormState value, $Res Function(CreateTalkFormState) then) =
-      _$CreateTalkFormStateCopyWithImpl<$Res, CreateTalkFormState>;
+abstract class $CreateTalkGroupFormStateCopyWith<$Res> {
+  factory $CreateTalkGroupFormStateCopyWith(CreateTalkGroupFormState value,
+          $Res Function(CreateTalkGroupFormState) then) =
+      _$CreateTalkGroupFormStateCopyWithImpl<$Res, CreateTalkGroupFormState>;
   @useResult
   $Res call(
       {String name,
@@ -46,9 +198,10 @@ abstract class $CreateTalkFormStateCopyWith<$Res> {
 }
 
 /// @nodoc
-class _$CreateTalkFormStateCopyWithImpl<$Res, $Val extends CreateTalkFormState>
-    implements $CreateTalkFormStateCopyWith<$Res> {
-  _$CreateTalkFormStateCopyWithImpl(this._value, this._then);
+class _$CreateTalkGroupFormStateCopyWithImpl<$Res,
+        $Val extends CreateTalkGroupFormState>
+    implements $CreateTalkGroupFormStateCopyWith<$Res> {
+  _$CreateTalkGroupFormStateCopyWithImpl(this._value, this._then);
 
   // ignore: unused_field
   final $Val _value;
@@ -114,11 +267,12 @@ class _$CreateTalkFormStateCopyWithImpl<$Res, $Val extends CreateTalkFormState>
 }
 
 /// @nodoc
-abstract class _$$_CreateTalkFormStateCopyWith<$Res>
-    implements $CreateTalkFormStateCopyWith<$Res> {
-  factory _$$_CreateTalkFormStateCopyWith(_$_CreateTalkFormState value,
-          $Res Function(_$_CreateTalkFormState) then) =
-      __$$_CreateTalkFormStateCopyWithImpl<$Res>;
+abstract class _$$_CreateTalkGroupFormStateCopyWith<$Res>
+    implements $CreateTalkGroupFormStateCopyWith<$Res> {
+  factory _$$_CreateTalkGroupFormStateCopyWith(
+          _$_CreateTalkGroupFormState value,
+          $Res Function(_$_CreateTalkGroupFormState) then) =
+      __$$_CreateTalkGroupFormStateCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -135,11 +289,12 @@ abstract class _$$_CreateTalkFormStateCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_CreateTalkFormStateCopyWithImpl<$Res>
-    extends _$CreateTalkFormStateCopyWithImpl<$Res, _$_CreateTalkFormState>
-    implements _$$_CreateTalkFormStateCopyWith<$Res> {
-  __$$_CreateTalkFormStateCopyWithImpl(_$_CreateTalkFormState _value,
-      $Res Function(_$_CreateTalkFormState) _then)
+class __$$_CreateTalkGroupFormStateCopyWithImpl<$Res>
+    extends _$CreateTalkGroupFormStateCopyWithImpl<$Res,
+        _$_CreateTalkGroupFormState>
+    implements _$$_CreateTalkGroupFormStateCopyWith<$Res> {
+  __$$_CreateTalkGroupFormStateCopyWithImpl(_$_CreateTalkGroupFormState _value,
+      $Res Function(_$_CreateTalkGroupFormState) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -151,7 +306,7 @@ class __$$_CreateTalkFormStateCopyWithImpl<$Res>
     Object? adminAddFieldValue = freezed,
     Object? admins = null,
   }) {
-    return _then(_$_CreateTalkFormState(
+    return _then(_$_CreateTalkGroupFormState(
       name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
@@ -178,8 +333,8 @@ class __$$_CreateTalkFormStateCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$_CreateTalkFormState extends _CreateTalkFormState {
-  const _$_CreateTalkFormState(
+class _$_CreateTalkGroupFormState extends _CreateTalkGroupFormState {
+  const _$_CreateTalkGroupFormState(
       {required this.name,
       this.memberAddFieldValue,
       required final List<AccessRecipient> members,
@@ -213,14 +368,14 @@ class _$_CreateTalkFormState extends _CreateTalkFormState {
 
   @override
   String toString() {
-    return 'CreateTalkFormState(name: $name, memberAddFieldValue: $memberAddFieldValue, members: $members, adminAddFieldValue: $adminAddFieldValue, admins: $admins)';
+    return 'CreateTalkGroupFormState(name: $name, memberAddFieldValue: $memberAddFieldValue, members: $members, adminAddFieldValue: $adminAddFieldValue, admins: $admins)';
   }
 
   @override
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CreateTalkFormState &&
+            other is _$_CreateTalkGroupFormState &&
             (identical(other.name, name) || other.name == name) &&
             (identical(other.memberAddFieldValue, memberAddFieldValue) ||
                 other.memberAddFieldValue == memberAddFieldValue) &&
@@ -242,19 +397,20 @@ class _$_CreateTalkFormState extends _CreateTalkFormState {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CreateTalkFormStateCopyWith<_$_CreateTalkFormState> get copyWith =>
-      __$$_CreateTalkFormStateCopyWithImpl<_$_CreateTalkFormState>(
-          this, _$identity);
+  _$$_CreateTalkGroupFormStateCopyWith<_$_CreateTalkGroupFormState>
+      get copyWith => __$$_CreateTalkGroupFormStateCopyWithImpl<
+          _$_CreateTalkGroupFormState>(this, _$identity);
 }
 
-abstract class _CreateTalkFormState extends CreateTalkFormState {
-  const factory _CreateTalkFormState(
-      {required final String name,
-      final AccessRecipient? memberAddFieldValue,
-      required final List<AccessRecipient> members,
-      final AccessRecipient? adminAddFieldValue,
-      required final List<AccessRecipient> admins}) = _$_CreateTalkFormState;
-  const _CreateTalkFormState._() : super._();
+abstract class _CreateTalkGroupFormState extends CreateTalkGroupFormState {
+  const factory _CreateTalkGroupFormState(
+          {required final String name,
+          final AccessRecipient? memberAddFieldValue,
+          required final List<AccessRecipient> members,
+          final AccessRecipient? adminAddFieldValue,
+          required final List<AccessRecipient> admins}) =
+      _$_CreateTalkGroupFormState;
+  const _CreateTalkGroupFormState._() : super._();
 
   @override
   String get name;
@@ -268,8 +424,8 @@ abstract class _CreateTalkFormState extends CreateTalkFormState {
   List<AccessRecipient> get admins;
   @override
   @JsonKey(ignore: true)
-  _$$_CreateTalkFormStateCopyWith<_$_CreateTalkFormState> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$_CreateTalkGroupFormStateCopyWith<_$_CreateTalkGroupFormState>
+      get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc

--- a/lib/ui/views/messenger/bloc/providers.g.dart
+++ b/lib/ui/views/messenger/bloc/providers.g.dart
@@ -29,8 +29,6 @@ class _SystemHash {
   }
 }
 
-typedef _TalkRef = AutoDisposeFutureProviderRef<Talk>;
-
 /// See also [_talk].
 @ProviderFor(_talk)
 const _talkProvider = _TalkFamily();
@@ -77,10 +75,10 @@ class _TalkFamily extends Family<AsyncValue<Talk>> {
 class _TalkProvider extends AutoDisposeFutureProvider<Talk> {
   /// See also [_talk].
   _TalkProvider(
-    this.address,
-  ) : super.internal(
+    String address,
+  ) : this._internal(
           (ref) => _talk(
-            ref,
+            ref as _TalkRef,
             address,
           ),
           from: _talkProvider,
@@ -89,9 +87,43 @@ class _TalkProvider extends AutoDisposeFutureProvider<Talk> {
               const bool.fromEnvironment('dart.vm.product') ? null : _$talkHash,
           dependencies: _TalkFamily._dependencies,
           allTransitiveDependencies: _TalkFamily._allTransitiveDependencies,
+          address: address,
         );
 
+  _TalkProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.address,
+  }) : super.internal();
+
   final String address;
+
+  @override
+  Override overrideWith(
+    FutureOr<Talk> Function(_TalkRef provider) create,
+  ) {
+    return ProviderOverride(
+      origin: this,
+      override: _TalkProvider._internal(
+        (ref) => create(ref as _TalkRef),
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        address: address,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeFutureProviderElement<Talk> createElement() {
+    return _TalkProviderElement(this);
+  }
 
   @override
   bool operator ==(Object other) {
@@ -107,8 +139,20 @@ class _TalkProvider extends AutoDisposeFutureProvider<Talk> {
   }
 }
 
+mixin _TalkRef on AutoDisposeFutureProviderRef<Talk> {
+  /// The parameter `address` of this provider.
+  String get address;
+}
+
+class _TalkProviderElement extends AutoDisposeFutureProviderElement<Talk>
+    with _TalkRef {
+  _TalkProviderElement(super.provider);
+
+  @override
+  String get address => (origin as _TalkProvider).address;
+}
+
 String _$talkDisplayNameHash() => r'0c804df14048c53d1983cf9a77d360f791a454e4';
-typedef _TalkDisplayNameRef = AutoDisposeProviderRef<String>;
 
 /// See also [_talkDisplayName].
 @ProviderFor(_talkDisplayName)
@@ -156,10 +200,10 @@ class _TalkDisplayNameFamily extends Family<String> {
 class _TalkDisplayNameProvider extends AutoDisposeProvider<String> {
   /// See also [_talkDisplayName].
   _TalkDisplayNameProvider(
-    this.talk,
-  ) : super.internal(
+    Talk talk,
+  ) : this._internal(
           (ref) => _talkDisplayName(
-            ref,
+            ref as _TalkDisplayNameRef,
             talk,
           ),
           from: _talkDisplayNameProvider,
@@ -171,9 +215,43 @@ class _TalkDisplayNameProvider extends AutoDisposeProvider<String> {
           dependencies: _TalkDisplayNameFamily._dependencies,
           allTransitiveDependencies:
               _TalkDisplayNameFamily._allTransitiveDependencies,
+          talk: talk,
         );
 
+  _TalkDisplayNameProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.talk,
+  }) : super.internal();
+
   final Talk talk;
+
+  @override
+  Override overrideWith(
+    String Function(_TalkDisplayNameRef provider) create,
+  ) {
+    return ProviderOverride(
+      origin: this,
+      override: _TalkDisplayNameProvider._internal(
+        (ref) => create(ref as _TalkDisplayNameRef),
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        talk: talk,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeProviderElement<String> createElement() {
+    return _TalkDisplayNameProviderElement(this);
+  }
 
   @override
   bool operator ==(Object other) {
@@ -189,10 +267,21 @@ class _TalkDisplayNameProvider extends AutoDisposeProvider<String> {
   }
 }
 
+mixin _TalkDisplayNameRef on AutoDisposeProviderRef<String> {
+  /// The parameter `talk` of this provider.
+  Talk get talk;
+}
+
+class _TalkDisplayNameProviderElement extends AutoDisposeProviderElement<String>
+    with _TalkDisplayNameRef {
+  _TalkDisplayNameProviderElement(super.provider);
+
+  @override
+  Talk get talk => (origin as _TalkDisplayNameProvider).talk;
+}
+
 String _$accessRecipientWithPublicKeyHash() =>
     r'8cd0c92d333699019c70fa46161053c030e3e555';
-typedef _AccessRecipientWithPublicKeyRef
-    = AutoDisposeFutureProviderRef<AccessRecipient>;
 
 /// See also [_accessRecipientWithPublicKey].
 @ProviderFor(_accessRecipientWithPublicKey)
@@ -243,10 +332,10 @@ class _AccessRecipientWithPublicKeyProvider
     extends AutoDisposeFutureProvider<AccessRecipient> {
   /// See also [_accessRecipientWithPublicKey].
   _AccessRecipientWithPublicKeyProvider(
-    this.pubKey,
-  ) : super.internal(
+    String pubKey,
+  ) : this._internal(
           (ref) => _accessRecipientWithPublicKey(
-            ref,
+            ref as _AccessRecipientWithPublicKeyRef,
             pubKey,
           ),
           from: _accessRecipientWithPublicKeyProvider,
@@ -258,9 +347,45 @@ class _AccessRecipientWithPublicKeyProvider
           dependencies: _AccessRecipientWithPublicKeyFamily._dependencies,
           allTransitiveDependencies:
               _AccessRecipientWithPublicKeyFamily._allTransitiveDependencies,
+          pubKey: pubKey,
         );
 
+  _AccessRecipientWithPublicKeyProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.pubKey,
+  }) : super.internal();
+
   final String pubKey;
+
+  @override
+  Override overrideWith(
+    FutureOr<AccessRecipient> Function(
+            _AccessRecipientWithPublicKeyRef provider)
+        create,
+  ) {
+    return ProviderOverride(
+      origin: this,
+      override: _AccessRecipientWithPublicKeyProvider._internal(
+        (ref) => create(ref as _AccessRecipientWithPublicKeyRef),
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        pubKey: pubKey,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeFutureProviderElement<AccessRecipient> createElement() {
+    return _AccessRecipientWithPublicKeyProviderElement(this);
+  }
 
   @override
   bool operator ==(Object other) {
@@ -277,8 +402,22 @@ class _AccessRecipientWithPublicKeyProvider
   }
 }
 
+mixin _AccessRecipientWithPublicKeyRef
+    on AutoDisposeFutureProviderRef<AccessRecipient> {
+  /// The parameter `pubKey` of this provider.
+  String get pubKey;
+}
+
+class _AccessRecipientWithPublicKeyProviderElement
+    extends AutoDisposeFutureProviderElement<AccessRecipient>
+    with _AccessRecipientWithPublicKeyRef {
+  _AccessRecipientWithPublicKeyProviderElement(super.provider);
+
+  @override
+  String get pubKey => (origin as _AccessRecipientWithPublicKeyProvider).pubKey;
+}
+
 String _$remoteTalkHash() => r'ed7b1d88182f4cdacb77c6ddbb6ca827ce2ae567';
-typedef _RemoteTalkRef = AutoDisposeFutureProviderRef<Talk>;
 
 /// See also [_remoteTalk].
 @ProviderFor(_remoteTalk)
@@ -326,10 +465,10 @@ class _RemoteTalkFamily extends Family<AsyncValue<Talk>> {
 class _RemoteTalkProvider extends AutoDisposeFutureProvider<Talk> {
   /// See also [_remoteTalk].
   _RemoteTalkProvider(
-    this.address,
-  ) : super.internal(
+    String address,
+  ) : this._internal(
           (ref) => _remoteTalk(
-            ref,
+            ref as _TalkRef,
             address,
           ),
           from: _remoteTalkProvider,
@@ -341,9 +480,43 @@ class _RemoteTalkProvider extends AutoDisposeFutureProvider<Talk> {
           dependencies: _RemoteTalkFamily._dependencies,
           allTransitiveDependencies:
               _RemoteTalkFamily._allTransitiveDependencies,
+          address: address,
         );
 
+  _RemoteTalkProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.address,
+  }) : super.internal();
+
   final String address;
+
+  @override
+  Override overrideWith(
+    FutureOr<Talk> Function(_RemoteTalkRef provider) create,
+  ) {
+    return ProviderOverride(
+      origin: this,
+      override: _RemoteTalkProvider._internal(
+        (ref) => create(ref as _RemoteTalkRef),
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        address: address,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeFutureProviderElement<Talk> createElement() {
+    return _RemoteTalkProviderElement(this);
+  }
 
   @override
   bool operator ==(Object other) {
@@ -357,6 +530,19 @@ class _RemoteTalkProvider extends AutoDisposeFutureProvider<Talk> {
 
     return _SystemHash.finish(hash);
   }
+}
+
+mixin _RemoteTalkRef on AutoDisposeFutureProviderRef<Talk> {
+  /// The parameter `address` of this provider.
+  String get address;
+}
+
+class _RemoteTalkProviderElement extends AutoDisposeFutureProviderElement<Talk>
+    with _RemoteTalkRef {
+  _RemoteTalkProviderElement(super.provider);
+
+  @override
+  String get address => (origin as _RemoteTalkProvider).address;
 }
 
 String _$sortedTalksHash() => r'a69c62e57de2860c16c0b8d09c73490816d807a1';
@@ -375,7 +561,6 @@ final _sortedTalksProvider = AutoDisposeFutureProvider<List<Talk>>.internal(
 typedef _SortedTalksRef = AutoDisposeFutureProviderRef<List<Talk>>;
 String _$messageCreationFeesHash() =>
     r'd73daff392d278e20cddfd6d6fe9e3e1d46f71e9';
-typedef _MessageCreationFeesRef = AutoDisposeFutureProviderRef<double>;
 
 /// See also [_messageCreationFees].
 @ProviderFor(_messageCreationFees)
@@ -426,11 +611,11 @@ class _MessageCreationFeesFamily extends Family<AsyncValue<double>> {
 class _MessageCreationFeesProvider extends AutoDisposeFutureProvider<double> {
   /// See also [_messageCreationFees].
   _MessageCreationFeesProvider(
-    this.talkAddress,
-    this.content,
-  ) : super.internal(
+    String talkAddress,
+    String content,
+  ) : this._internal(
           (ref) => _messageCreationFees(
-            ref,
+            ref as _MessageCreationFeesRef,
             talkAddress,
             content,
           ),
@@ -443,10 +628,47 @@ class _MessageCreationFeesProvider extends AutoDisposeFutureProvider<double> {
           dependencies: _MessageCreationFeesFamily._dependencies,
           allTransitiveDependencies:
               _MessageCreationFeesFamily._allTransitiveDependencies,
+          talkAddress: talkAddress,
+          content: content,
         );
+
+  _MessageCreationFeesProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.talkAddress,
+    required this.content,
+  }) : super.internal();
 
   final String talkAddress;
   final String content;
+
+  @override
+  Override overrideWith(
+    FutureOr<double> Function(_MessageCreationFeesRef provider) create,
+  ) {
+    return ProviderOverride(
+      origin: this,
+      override: _MessageCreationFeesProvider._internal(
+        (ref) => create(ref as _MessageCreationFeesRef),
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        talkAddress: talkAddress,
+        content: content,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeFutureProviderElement<double> createElement() {
+    return _MessageCreationFeesProviderElement(this);
+  }
 
   @override
   bool operator ==(Object other) {
@@ -465,8 +687,27 @@ class _MessageCreationFeesProvider extends AutoDisposeFutureProvider<double> {
   }
 }
 
+mixin _MessageCreationFeesRef on AutoDisposeFutureProviderRef<double> {
+  /// The parameter `talkAddress` of this provider.
+  String get talkAddress;
+
+  /// The parameter `content` of this provider.
+  String get content;
+}
+
+class _MessageCreationFeesProviderElement
+    extends AutoDisposeFutureProviderElement<double>
+    with _MessageCreationFeesRef {
+  _MessageCreationFeesProviderElement(super.provider);
+
+  @override
+  String get talkAddress =>
+      (origin as _MessageCreationFeesProvider).talkAddress;
+  @override
+  String get content => (origin as _MessageCreationFeesProvider).content;
+}
+
 String _$talkMessagesHash() => r'b145aeb4672f368d39954ad88a45cd9eee51154b';
-typedef _TalkMessagesRef = AutoDisposeFutureProviderRef<List<TalkMessage>>;
 
 /// See also [_talkMessages].
 @ProviderFor(_talkMessages)
@@ -521,12 +762,12 @@ class _TalkMessagesProvider
     extends AutoDisposeFutureProvider<List<TalkMessage>> {
   /// See also [_talkMessages].
   _TalkMessagesProvider(
-    this.talkAddress,
-    this.offset,
-    this.pageSize,
-  ) : super.internal(
+    String talkAddress,
+    int offset,
+    int pageSize,
+  ) : this._internal(
           (ref) => _talkMessages(
-            ref,
+            ref as _TalkMessagesRef,
             talkAddress,
             offset,
             pageSize,
@@ -540,11 +781,51 @@ class _TalkMessagesProvider
           dependencies: _TalkMessagesFamily._dependencies,
           allTransitiveDependencies:
               _TalkMessagesFamily._allTransitiveDependencies,
+          talkAddress: talkAddress,
+          offset: offset,
+          pageSize: pageSize,
         );
+
+  _TalkMessagesProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.talkAddress,
+    required this.offset,
+    required this.pageSize,
+  }) : super.internal();
 
   final String talkAddress;
   final int offset;
   final int pageSize;
+
+  @override
+  Override overrideWith(
+    FutureOr<List<TalkMessage>> Function(_TalkMessagesRef provider) create,
+  ) {
+    return ProviderOverride(
+      origin: this,
+      override: _TalkMessagesProvider._internal(
+        (ref) => create(ref as _TalkMessagesRef),
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        talkAddress: talkAddress,
+        offset: offset,
+        pageSize: pageSize,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeFutureProviderElement<List<TalkMessage>> createElement() {
+    return _TalkMessagesProviderElement(this);
+  }
 
   @override
   bool operator ==(Object other) {
@@ -563,6 +844,30 @@ class _TalkMessagesProvider
 
     return _SystemHash.finish(hash);
   }
+}
+
+mixin _TalkMessagesRef on AutoDisposeFutureProviderRef<List<TalkMessage>> {
+  /// The parameter `talkAddress` of this provider.
+  String get talkAddress;
+
+  /// The parameter `offset` of this provider.
+  int get offset;
+
+  /// The parameter `pageSize` of this provider.
+  int get pageSize;
+}
+
+class _TalkMessagesProviderElement
+    extends AutoDisposeFutureProviderElement<List<TalkMessage>>
+    with _TalkMessagesRef {
+  _TalkMessagesProviderElement(super.provider);
+
+  @override
+  String get talkAddress => (origin as _TalkMessagesProvider).talkAddress;
+  @override
+  int get offset => (origin as _TalkMessagesProvider).offset;
+  @override
+  int get pageSize => (origin as _TalkMessagesProvider).pageSize;
 }
 
 String _$talksHash() => r'81be6d6bc0cd5bbdf9a1f0dbdea3712829bf8e5e';
@@ -642,8 +947,8 @@ class _MessageCreationFormNotifierProvider
         MessageCreationFormState> {
   /// See also [_MessageCreationFormNotifier].
   _MessageCreationFormNotifierProvider(
-    this.talkAddress,
-  ) : super.internal(
+    String talkAddress,
+  ) : this._internal(
           () => _MessageCreationFormNotifier()..talkAddress = talkAddress,
           from: _messageCreationFormNotifierProvider,
           name: r'_messageCreationFormNotifierProvider',
@@ -654,9 +959,51 @@ class _MessageCreationFormNotifierProvider
           dependencies: _MessageCreationFormNotifierFamily._dependencies,
           allTransitiveDependencies:
               _MessageCreationFormNotifierFamily._allTransitiveDependencies,
+          talkAddress: talkAddress,
         );
 
+  _MessageCreationFormNotifierProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.talkAddress,
+  }) : super.internal();
+
   final String talkAddress;
+
+  @override
+  MessageCreationFormState runNotifierBuild(
+    covariant _MessageCreationFormNotifier notifier,
+  ) {
+    return notifier.build(
+      talkAddress,
+    );
+  }
+
+  @override
+  Override overrideWith(_MessageCreationFormNotifier Function() create) {
+    return ProviderOverride(
+      origin: this,
+      override: _MessageCreationFormNotifierProvider._internal(
+        () => create()..talkAddress = talkAddress,
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        talkAddress: talkAddress,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeNotifierProviderElement<_MessageCreationFormNotifier,
+      MessageCreationFormState> createElement() {
+    return _MessageCreationFormNotifierProviderElement(this);
+  }
 
   @override
   bool operator ==(Object other) {
@@ -671,19 +1018,26 @@ class _MessageCreationFormNotifierProvider
 
     return _SystemHash.finish(hash);
   }
+}
+
+mixin _MessageCreationFormNotifierRef
+    on AutoDisposeNotifierProviderRef<MessageCreationFormState> {
+  /// The parameter `talkAddress` of this provider.
+  String get talkAddress;
+}
+
+class _MessageCreationFormNotifierProviderElement
+    extends AutoDisposeNotifierProviderElement<_MessageCreationFormNotifier,
+        MessageCreationFormState> with _MessageCreationFormNotifierRef {
+  _MessageCreationFormNotifierProviderElement(super.provider);
 
   @override
-  MessageCreationFormState runNotifierBuild(
-    covariant _MessageCreationFormNotifier notifier,
-  ) {
-    return notifier.build(
-      talkAddress,
-    );
-  }
+  String get talkAddress =>
+      (origin as _MessageCreationFormNotifierProvider).talkAddress;
 }
 
 String _$paginatedTalkMessagesNotifierHash() =>
-    r'e99219c552e4a1d3a67875f97ab62c6056d639a7';
+    r'b188e1e48f28cbcd36df4beae1f1f252e95af29a';
 
 abstract class _$PaginatedTalkMessagesNotifier
     extends BuildlessAutoDisposeNotifier<PagingController<int, TalkMessage>> {
@@ -744,8 +1098,8 @@ class _PaginatedTalkMessagesNotifierProvider
         PagingController<int, TalkMessage>> {
   /// See also [_PaginatedTalkMessagesNotifier].
   _PaginatedTalkMessagesNotifierProvider(
-    this.talkAddress,
-  ) : super.internal(
+    String talkAddress,
+  ) : this._internal(
           () => _PaginatedTalkMessagesNotifier()..talkAddress = talkAddress,
           from: _paginatedTalkMessagesNotifierProvider,
           name: r'_paginatedTalkMessagesNotifierProvider',
@@ -756,9 +1110,51 @@ class _PaginatedTalkMessagesNotifierProvider
           dependencies: _PaginatedTalkMessagesNotifierFamily._dependencies,
           allTransitiveDependencies:
               _PaginatedTalkMessagesNotifierFamily._allTransitiveDependencies,
+          talkAddress: talkAddress,
         );
 
+  _PaginatedTalkMessagesNotifierProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.talkAddress,
+  }) : super.internal();
+
   final String talkAddress;
+
+  @override
+  PagingController<int, TalkMessage> runNotifierBuild(
+    covariant _PaginatedTalkMessagesNotifier notifier,
+  ) {
+    return notifier.build(
+      talkAddress,
+    );
+  }
+
+  @override
+  Override overrideWith(_PaginatedTalkMessagesNotifier Function() create) {
+    return ProviderOverride(
+      origin: this,
+      override: _PaginatedTalkMessagesNotifierProvider._internal(
+        () => create()..talkAddress = talkAddress,
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        talkAddress: talkAddress,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeNotifierProviderElement<_PaginatedTalkMessagesNotifier,
+      PagingController<int, TalkMessage>> createElement() {
+    return _PaginatedTalkMessagesNotifierProviderElement(this);
+  }
 
   @override
   bool operator ==(Object other) {
@@ -773,15 +1169,23 @@ class _PaginatedTalkMessagesNotifierProvider
 
     return _SystemHash.finish(hash);
   }
+}
+
+mixin _PaginatedTalkMessagesNotifierRef
+    on AutoDisposeNotifierProviderRef<PagingController<int, TalkMessage>> {
+  /// The parameter `talkAddress` of this provider.
+  String get talkAddress;
+}
+
+class _PaginatedTalkMessagesNotifierProviderElement
+    extends AutoDisposeNotifierProviderElement<_PaginatedTalkMessagesNotifier,
+        PagingController<int, TalkMessage>>
+    with _PaginatedTalkMessagesNotifierRef {
+  _PaginatedTalkMessagesNotifierProviderElement(super.provider);
 
   @override
-  PagingController<int, TalkMessage> runNotifierBuild(
-    covariant _PaginatedTalkMessagesNotifier notifier,
-  ) {
-    return notifier.build(
-      talkAddress,
-    );
-  }
+  String get talkAddress =>
+      (origin as _PaginatedTalkMessagesNotifierProvider).talkAddress;
 }
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member

--- a/lib/ui/views/messenger/layouts/create_talk_contact_sheet.dart
+++ b/lib/ui/views/messenger/layouts/create_talk_contact_sheet.dart
@@ -1,5 +1,6 @@
 import 'package:aewallet/application/settings/theme.dart';
 import 'package:aewallet/model/data/contact.dart';
+import 'package:aewallet/ui/util/contact_formatters.dart';
 import 'package:aewallet/ui/util/dimens.dart';
 import 'package:aewallet/ui/util/styles.dart';
 import 'package:aewallet/ui/util/ui_util.dart';
@@ -37,7 +38,7 @@ class _CreateTalkContactSheetState
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       ref
           .read(MessengerProviders.talkContactCreationForm.notifier)
-          .setName(widget.contact.displayName);
+          .setName(widget.contact.format);
       final member = AddPublicKeyTextFieldValue.contact(contact: widget.contact)
           .toAccessRecipient!;
       ref
@@ -114,7 +115,7 @@ class _CreateTalkContactSheetState
                       Row(
                         children: [
                           Text(
-                            widget.contact.displayName,
+                            widget.contact.format,
                             style: theme.textStyleSize16W700Primary,
                           ),
                           const Expanded(child: SizedBox()),

--- a/lib/ui/views/messenger/layouts/create_talk_contact_sheet.dart
+++ b/lib/ui/views/messenger/layouts/create_talk_contact_sheet.dart
@@ -1,0 +1,188 @@
+import 'package:aewallet/application/settings/theme.dart';
+import 'package:aewallet/model/data/contact.dart';
+import 'package:aewallet/ui/util/dimens.dart';
+import 'package:aewallet/ui/util/styles.dart';
+import 'package:aewallet/ui/util/ui_util.dart';
+import 'package:aewallet/ui/views/contacts/layouts/contact_detail.dart';
+import 'package:aewallet/ui/views/messenger/bloc/providers.dart';
+import 'package:aewallet/ui/views/messenger/layouts/components/add_public_key_textfield_pk.dart';
+import 'package:aewallet/ui/widgets/components/app_button_tiny.dart';
+import 'package:aewallet/ui/widgets/components/scrollbar.dart';
+import 'package:aewallet/ui/widgets/components/sheet_util.dart';
+import 'package:aewallet/ui/widgets/components/show_sending_animation.dart';
+import 'package:aewallet/ui/widgets/components/tap_outside_unfocus.dart';
+import 'package:auto_size_text/auto_size_text.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class CreateTalkContactSheet extends ConsumerStatefulWidget {
+  const CreateTalkContactSheet({
+    super.key,
+    required this.contact,
+  });
+
+  final Contact contact;
+
+  @override
+  ConsumerState<CreateTalkContactSheet> createState() =>
+      _CreateTalkContactSheetState();
+}
+
+class _CreateTalkContactSheetState
+    extends ConsumerState<CreateTalkContactSheet> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      ref
+          .read(MessengerProviders.talkContactCreationForm.notifier)
+          .setName(widget.contact.displayName);
+      final member = AddPublicKeyTextFieldValue.contact(contact: widget.contact)
+          .toAccessRecipient!;
+      ref
+          .read(MessengerProviders.talkContactCreationForm.notifier)
+          .addMember(member);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ref.watch(ThemeProviders.selectedTheme);
+    final localizations = AppLocalizations.of(context)!;
+    final bottom = MediaQuery.of(context).viewInsets.bottom;
+
+    final formNotifier =
+        ref.watch(MessengerProviders.talkContactCreationForm.notifier);
+
+    return TapOutsideUnfocus(
+      child: SafeArea(
+        minimum:
+            EdgeInsets.only(bottom: MediaQuery.of(context).size.height * 0.035),
+        child: Column(
+          children: <Widget>[
+            Column(
+              children: [
+                Container(
+                  margin: const EdgeInsets.only(top: 10, bottom: 15),
+                  height: 5,
+                  width: MediaQuery.of(context).size.width * 0.15,
+                  decoration: BoxDecoration(
+                    color: theme.text60,
+                    borderRadius: BorderRadius.circular(100),
+                  ),
+                ),
+                Row(
+                  children: [
+                    BackButton(
+                      key: const Key('back'),
+                      color: theme.text,
+                      onPressed: () {
+                        Navigator.pop(context);
+                      },
+                    ),
+                    AutoSizeText(
+                      localizations.newDiscussion,
+                      style: theme.textStyleSize24W700EquinoxPrimary,
+                      textAlign: TextAlign.center,
+                      maxLines: 1,
+                      stepGranularity: 0.1,
+                    ),
+                  ],
+                ),
+              ],
+            ),
+            Expanded(
+              child: ArchethicScrollbar(
+                child: Padding(
+                  padding: EdgeInsets.only(
+                    top: 20,
+                    left: 15,
+                    right: 15,
+                    bottom: bottom + 80,
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
+                      Text(
+                        localizations.aboutToCreateADiscussion,
+                        style: theme.textStyleSize14W600Primary,
+                      ),
+                      const SizedBox(
+                        height: 15,
+                      ),
+                      Row(
+                        children: [
+                          Text(
+                            widget.contact.displayName,
+                            style: theme.textStyleSize16W700Primary,
+                          ),
+                          const Expanded(child: SizedBox()),
+                          IconButton(
+                              onPressed: () {
+                                Sheets.showAppHeightNineSheet(
+                                  context: context,
+                                  ref: ref,
+                                  widget: ContactDetail(
+                                    contact: widget.contact,
+                                    editMode: false,
+                                  ),
+                                );
+                              },
+                              icon: const Icon(Icons.info_outline)),
+                        ],
+                      ),
+                      const SizedBox(
+                        height: 30,
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+            Row(
+              children: <Widget>[
+                AppButtonTiny(
+                  AppButtonTinyType.primary,
+                  localizations.createDiscussion,
+                  Dimens.buttonBottomDimens,
+                  key: const Key('addMessengerTalk'),
+                  icon: Icon(
+                    Icons.add,
+                    color: theme.mainButtonLabel,
+                    size: 14,
+                  ),
+                  onPressed: () async {
+                    ShowSendingAnimation.build(
+                      context,
+                      theme,
+                    );
+                    final result = await formNotifier.createTalk();
+                    Navigator.of(context).pop(); // wait popup
+
+                    result.map(
+                      success: (success) {
+                        Navigator.of(context).pop(); // new contact sheet
+                        Navigator.of(context).pop(); // new talk sheet
+                      },
+                      failure: (failure) {
+                        UIUtil.showSnackbar(
+                          localizations.addMessengerTalkFailure,
+                          context,
+                          ref,
+                          theme.text!,
+                          theme.snackBarShadow!,
+                          duration: const Duration(seconds: 5),
+                        );
+                      },
+                    );
+                  },
+                )
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/views/messenger/layouts/create_talk_group_sheet.dart
+++ b/lib/ui/views/messenger/layouts/create_talk_group_sheet.dart
@@ -17,8 +17,8 @@ import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class CreateGroupSheet extends ConsumerWidget {
-  const CreateGroupSheet({super.key});
+class CreateTalkGroupSheet extends ConsumerWidget {
+  const CreateTalkGroupSheet({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -27,8 +27,8 @@ class CreateGroupSheet extends ConsumerWidget {
     final bottom = MediaQuery.of(context).viewInsets.bottom;
 
     final formNotifier =
-        ref.watch(MessengerProviders.talkCreationForm.notifier);
-    final formState = ref.watch(MessengerProviders.talkCreationForm);
+        ref.watch(MessengerProviders.talkGroupCreationForm.notifier);
+    final formState = ref.watch(MessengerProviders.talkGroupCreationForm);
 
     return TapOutsideUnfocus(
       child: SafeArea(
@@ -233,7 +233,7 @@ class _AddMessengerTalkNameTextFieldState
     final theme = ref.watch(ThemeProviders.selectedTheme);
     final localizations = AppLocalizations.of(context)!;
     final createTalkFormNotifier =
-        ref.watch(MessengerProviders.talkCreationForm.notifier);
+        ref.watch(MessengerProviders.talkGroupCreationForm.notifier);
 
     return AppTextField(
       focusNode: nameFocusNode,

--- a/lib/ui/views/messenger/layouts/create_talk_sheet.dart
+++ b/lib/ui/views/messenger/layouts/create_talk_sheet.dart
@@ -1,10 +1,12 @@
 import 'package:aewallet/application/account/providers.dart';
 import 'package:aewallet/application/contact.dart';
 import 'package:aewallet/application/settings/theme.dart';
+import 'package:aewallet/model/data/contact.dart';
 import 'package:aewallet/ui/util/contact_formatters.dart';
 import 'package:aewallet/ui/util/styles.dart';
 import 'package:aewallet/ui/views/contacts/layouts/add_contact.dart';
-import 'package:aewallet/ui/views/messenger/layouts/create_group_sheet.dart';
+import 'package:aewallet/ui/views/messenger/layouts/create_talk_contact_sheet.dart';
+import 'package:aewallet/ui/views/messenger/layouts/create_talk_group_sheet.dart';
 import 'package:aewallet/ui/widgets/components/picker_item.dart';
 import 'package:aewallet/ui/widgets/components/scrollbar.dart';
 import 'package:aewallet/ui/widgets/components/sheet_header.dart';
@@ -55,7 +57,7 @@ class CreateTalkSheet extends ConsumerWidget {
         child: Column(
           children: <Widget>[
             SheetHeader(
-              title: localizations.newTalk,
+              title: localizations.newDiscussion,
             ),
             Expanded(
               child: ArchethicScrollbar(
@@ -77,7 +79,7 @@ class CreateTalkSheet extends ConsumerWidget {
                               Sheets.showAppHeightNineSheet(
                                 context: context,
                                 ref: ref,
-                                widget: const CreateGroupSheet(),
+                                widget: const CreateTalkGroupSheet(),
                               );
                             },
                             child: Row(
@@ -149,8 +151,15 @@ class CreateTalkSheet extends ConsumerWidget {
                         child: SingleChildScrollView(
                           child: PickerWidget(
                             pickerItems: pickerItemsList,
+                            showSelectedItem: false,
                             onSelected: (value) {
-                              Navigator.pop(context, value.value);
+                              Sheets.showAppHeightNineSheet(
+                                context: context,
+                                ref: ref,
+                                widget: CreateTalkContactSheet(
+                                  contact: value.value as Contact,
+                                ),
+                              );
                             },
                           ),
                         ),

--- a/lib/ui/widgets/components/picker_item.dart
+++ b/lib/ui/widgets/components/picker_item.dart
@@ -36,15 +36,16 @@ class PickerItem<T extends Object> {
 
 // TODO(reddwarf03): specify [PickerItem.value] types (thanks to Generics) (3)
 class PickerWidget<T extends Object> extends ConsumerStatefulWidget {
-  const PickerWidget({
-    super.key,
-    this.pickerItems,
-    this.onSelected,
-    this.selectedIndex = -1,
-  });
+  const PickerWidget(
+      {super.key,
+      this.pickerItems,
+      this.onSelected,
+      this.selectedIndex = -1,
+      this.showSelectedItem = true});
   final ValueChanged<PickerItem<T>>? onSelected;
   final List<PickerItem<T>>? pickerItems;
   final int selectedIndex;
+  final bool showSelectedItem;
 
   @override
   ConsumerState<PickerWidget> createState() => _PickerWidgetState();
@@ -78,7 +79,9 @@ class _PickerWidgetState extends ConsumerState<PickerWidget> {
                         FeedbackType.light,
                         preferences.activeVibrations,
                       );
-                  selectedIndex = index;
+                  if (widget.showSelectedItem == true) {
+                    selectedIndex = index;
+                  }
                   widget.onSelected!(widget.pickerItems![index]);
                   setState(() {});
                 }


### PR DESCRIPTION
# Description

Have the possibility to create a discussion with a contact only, without going through the creation of a group

Fixes # (issue)

## Type of change

- New feature (non-breaking change which adds functionality)

## Material used:

Please delete options that are not relevant.
- iOS (Smartphone/Tablet) : iPhone 14 Pro Max

## How Has This Been Tested?

The user can now see his contacts directly through the new discussion page. When he selects an existing contact, a screen is displayed to let him know that he is going to create a discussion with the contact. He can see the contact details if he wants. 
He can also, of course, directly create a discussion with the selected contact. 

### Patrol

Please list here the tests created in Patrol for this pull request.

## Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

## Useful info for the reviewer:
