### PR TITLE
Discussion details is not a sheet anymore but a full page

### DIFF
--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -569,5 +569,7 @@
   "noContacts": "You have no contacts",
   "aboutToCreateADiscussion": "You are about to create a discussion with",
   "discussionInfo": "Discussion info",
-  "modify": "Modify"
+  "modify": "Modify",
+  "discussionModifying": "Discussion modifying",
+  "admin": "Admin"
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -567,5 +567,6 @@
   "newContact": "New contact",
   "contactsHeader": "Contacts",
   "noContacts": "You have no contacts",
-  "aboutToCreateADiscussion": "You are about to create a discussion with"
+  "aboutToCreateADiscussion": "You are about to create a discussion with",
+  "discussionInfo": "Discussion info"
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -568,5 +568,6 @@
   "contactsHeader": "Contacts",
   "noContacts": "You have no contacts",
   "aboutToCreateADiscussion": "You are about to create a discussion with",
-  "discussionInfo": "Discussion info"
+  "discussionInfo": "Discussion info",
+  "modify": "Modify"
 }

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -546,5 +546,7 @@
 	"noContacts": "Vous n'avez aucun contact",
 	"aboutToCreateADiscussion": "Vous êtes sur le point de créer une discussion avec",
 	"discussionInfo": "Info de la discussion",
-	"modify": "Modifier"
+	"modify": "Modifier",
+	"discussionModifying": "Modification de la discussion",
+	"admin": "Admin"
 }

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -545,5 +545,6 @@
 	"contactsHeader": "Contacts",
 	"noContacts": "Vous n'avez aucun contact",
 	"aboutToCreateADiscussion": "Vous êtes sur le point de créer une discussion avec",
-	"discussionInfo": "Info de la discussion"
+	"discussionInfo": "Info de la discussion",
+	"modify": "Modifier"
 }

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -544,5 +544,6 @@
 	"newContact": "Nouveau contact",
 	"contactsHeader": "Contacts",
 	"noContacts": "Vous n'avez aucun contact",
-	"aboutToCreateADiscussion": "Vous êtes sur le point de créer une discussion avec"
+	"aboutToCreateADiscussion": "Vous êtes sur le point de créer une discussion avec",
+	"discussionInfo": "Info de la discussion"
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -31,6 +31,7 @@ import 'package:aewallet/ui/views/intro/intro_welcome.dart';
 import 'package:aewallet/ui/views/main/home_page.dart';
 import 'package:aewallet/ui/views/messenger/layouts/discussion_details_page.dart';
 import 'package:aewallet/ui/views/messenger/layouts/messenger_discussion_page.dart';
+import 'package:aewallet/ui/views/messenger/layouts/update_discussion_page.dart';
 import 'package:aewallet/ui/views/nft/layouts/nft_list_per_category.dart';
 import 'package:aewallet/ui/views/nft_creation/layouts/nft_creation_process_sheet.dart';
 import 'package:aewallet/ui/views/rpc_command_receiver/rpc_command_receiver.dart';
@@ -311,6 +312,11 @@ class AppState extends ConsumerState<App> with WidgetsBindingObserver {
               ),
               '/discussion_details': MaterialPageRoute(
                 builder: (_) => DiscussionDetailsPage(
+                  discussionAddress: settings.arguments! as String,
+                ),
+              ),
+              '/update_discussion': MaterialPageRoute(
+                builder: (_) => UpdateDiscussionPage(
                   discussionAddress: settings.arguments! as String,
                 ),
               ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -29,6 +29,7 @@ import 'package:aewallet/ui/views/intro/intro_new_wallet_disclaimer.dart';
 import 'package:aewallet/ui/views/intro/intro_new_wallet_get_first_infos.dart';
 import 'package:aewallet/ui/views/intro/intro_welcome.dart';
 import 'package:aewallet/ui/views/main/home_page.dart';
+import 'package:aewallet/ui/views/messenger/layouts/discussion_details_page.dart';
 import 'package:aewallet/ui/views/messenger/layouts/messenger_discussion_page.dart';
 import 'package:aewallet/ui/views/nft/layouts/nft_list_per_category.dart';
 import 'package:aewallet/ui/views/nft_creation/layouts/nft_creation_process_sheet.dart';
@@ -305,6 +306,11 @@ class AppState extends ConsumerState<App> with WidgetsBindingObserver {
               ),
               '/messenger_discussion': MaterialPageRoute(
                 builder: (_) => MessengerDiscussionPage(
+                  discussionAddress: settings.arguments! as String,
+                ),
+              ),
+              '/discussion_details': MaterialPageRoute(
+                builder: (_) => DiscussionDetailsPage(
                   discussionAddress: settings.arguments! as String,
                 ),
               ),

--- a/lib/ui/views/messenger/layouts/discussion_details_page.dart
+++ b/lib/ui/views/messenger/layouts/discussion_details_page.dart
@@ -55,97 +55,107 @@ class DiscussionDetailsPage extends ConsumerWidget {
         appBar: AppBar(
           backgroundColor: Colors.transparent,
           elevation: 0,
-          title: asyncDiscussion.maybeMap(
-            data: (data) {
-              final displayName = ref.watch(
-                MessengerProviders.discussionDisplayName(data.value),
-              );
-
-              return Text(displayName);
-            },
-            orElse: () => const Text('           ')
-                .animate(
-                  onComplete: (controller) =>
-                      controller.repeat(period: 1.seconds),
-                )
-                .shimmer(),
-          ),
+          title: Text(localizations.discussionInfo),
         ),
         body: TapOutsideUnfocus(
           child: SafeArea(
             minimum: EdgeInsets.only(
               bottom: MediaQuery.of(context).size.height * 0.035,
             ),
-            child: asyncDiscussion.maybeMap(
-              orElse: Container.new,
-              data: (discussion) {
-                return Column(
-                  children: <Widget>[
-                    _SectionTitle(
-                      text: localizations.messengerDiscussionMembersCount(
-                        discussion.value.membersPubKeys.length,
-                      ),
+            child: Padding(
+              padding: EdgeInsets.only(
+                left: 15,
+                right: 15,
+                bottom: bottom + 80,
+              ),
+              child: ArchethicScrollbar(
+                child: Column(
+                  children: [
+                    const SizedBox(
+                      height: 15,
                     ),
-                    Expanded(
-                      child: ArchethicScrollbar(
-                        child: Padding(
-                          padding: EdgeInsets.only(
-                            left: 15,
-                            right: 15,
-                            bottom: bottom + 80,
-                          ),
-                          child: Column(
-                            children:
-                                discussion.value.membersPubKeys.map((pubKey) {
-                              index++;
-                              final accessRecipient = ref.watch(
-                                MessengerProviders.accessRecipientWithPublicKey(
-                                  pubKey,
-                                ),
-                              );
+                    asyncDiscussion.maybeMap(
+                      data: (data) {
+                        final displayName = ref.watch(
+                          MessengerProviders.discussionDisplayName(data.value),
+                        );
 
-                              return PublicKeyLine(
-                                discussion: discussion.value,
-                                pubKey: pubKey,
-                                onTap: accessRecipient.maybeMap(
-                                  orElse: () => null,
-                                  data: (recipient) => recipient.value.map(
-                                    contact: (contact) => () {
-                                      sl.get<HapticUtil>().feedback(
-                                            FeedbackType.light,
-                                            settings.activeVibrations,
-                                          );
-
-                                      Sheets.showAppHeightNineSheet(
-                                        context: context,
-                                        ref: ref,
-                                        widget: ContactDetail(
-                                          contact: contact.contact,
-                                        ),
-                                      );
-                                    },
-                                    publicKey: (_) => null,
+                        return Text(
+                          displayName,
+                          textAlign: TextAlign.center,
+                          style: theme.textStyleSize28W700Primary,
+                        );
+                      },
+                      orElse: () => const SizedBox(),
+                    ),
+                    const SizedBox(
+                      height: 8,
+                    ),
+                    asyncDiscussion.maybeMap(
+                      orElse: Container.new,
+                      data: (discussion) {
+                        return Column(
+                          children: <Widget>[
+                            _SectionTitle(
+                              text:
+                                  localizations.messengerDiscussionMembersCount(
+                                discussion.value.membersPubKeys.length,
+                              ),
+                            ),
+                            Column(
+                              children:
+                                  discussion.value.membersPubKeys.map((pubKey) {
+                                index++;
+                                final accessRecipient = ref.watch(
+                                  MessengerProviders
+                                      .accessRecipientWithPublicKey(
+                                    pubKey,
                                   ),
-                                ),
-                              )
-                                  .animate(delay: (100 * index).ms)
-                                  .fadeIn(duration: 900.ms, delay: 200.ms)
-                                  .shimmer(
-                                    blendMode: BlendMode.srcOver,
-                                    color: Colors.white12,
-                                  )
-                                  .move(
-                                    begin: const Offset(-16, 0),
-                                    curve: Curves.easeOutQuad,
-                                  );
-                            }).toList(),
-                          ),
-                        ),
-                      ),
+                                );
+
+                                return PublicKeyLine(
+                                  discussion: discussion.value,
+                                  pubKey: pubKey,
+                                  onTap: accessRecipient.maybeMap(
+                                    orElse: () => null,
+                                    data: (recipient) => recipient.value.map(
+                                      contact: (contact) => () {
+                                        sl.get<HapticUtil>().feedback(
+                                              FeedbackType.light,
+                                              settings.activeVibrations,
+                                            );
+
+                                        Sheets.showAppHeightNineSheet(
+                                          context: context,
+                                          ref: ref,
+                                          widget: ContactDetail(
+                                            contact: contact.contact,
+                                          ),
+                                        );
+                                      },
+                                      publicKey: (_) => null,
+                                    ),
+                                  ),
+                                )
+                                    .animate(delay: (100 * index).ms)
+                                    .fadeIn(duration: 900.ms, delay: 200.ms)
+                                    .shimmer(
+                                      blendMode: BlendMode.srcOver,
+                                      color: Colors.white12,
+                                    )
+                                    .move(
+                                      begin: const Offset(-16, 0),
+                                      curve: Curves.easeOutQuad,
+                                    );
+                              }).toList(),
+                            ),
+                          ],
+                        );
+                      },
                     ),
                   ],
-                );
-              },
+                ),
+              ),
             ),
           ),
         ),

--- a/lib/ui/views/messenger/layouts/discussion_details_page.dart
+++ b/lib/ui/views/messenger/layouts/discussion_details_page.dart
@@ -265,8 +265,8 @@ class PublicKeyLine extends ConsumerWidget {
                 const Padding(
                   padding: EdgeInsets.only(left: 8),
                   child: Icon(
-                    Icons.arrow_forward_ios,
-                    size: 12,
+                    Icons.info_outline,
+                    size: 22,
                   ),
                 ),
             ],
@@ -289,14 +289,15 @@ class _MemberRole extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = ref.watch(ThemeProviders.selectedTheme);
+    final localizations = AppLocalizations.of(context)!;
     final isAdmin = discussion.adminsPubKeys.any(
       (adminPubKey) => adminPubKey == memberPubKey,
     );
 
     if (isAdmin) {
       return Text(
-        'Admin',
-        style: theme.textStyleSize12W100Primary,
+        localizations.admin,
+        style: theme.textStyleSize10W600Primary,
       );
     }
 

--- a/lib/ui/views/messenger/layouts/discussion_details_page.dart
+++ b/lib/ui/views/messenger/layouts/discussion_details_page.dart
@@ -56,6 +56,18 @@ class DiscussionDetailsPage extends ConsumerWidget {
           backgroundColor: Colors.transparent,
           elevation: 0,
           title: Text(localizations.discussionInfo),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pushNamed(
+                '/update_discussion',
+                arguments: discussionAddress,
+              ),
+              child: Text(
+                localizations.modify,
+                style: theme.textStyleSize12W400Primary,
+              ),
+            ),
+          ],
         ),
         body: TapOutsideUnfocus(
           child: SafeArea(

--- a/lib/ui/views/messenger/layouts/messenger_discussion_page.dart
+++ b/lib/ui/views/messenger/layouts/messenger_discussion_page.dart
@@ -8,8 +8,6 @@ import 'package:aewallet/ui/util/amount_formatters.dart';
 import 'package:aewallet/ui/util/contact_formatters.dart';
 import 'package:aewallet/ui/util/styles.dart';
 import 'package:aewallet/ui/views/messenger/bloc/providers.dart';
-import 'package:aewallet/ui/views/messenger/layouts/discussion_details_sheet.dart';
-import 'package:aewallet/ui/widgets/components/sheet_util.dart';
 import 'package:aewallet/util/currency_util.dart';
 import 'package:aewallet/util/date_util.dart';
 import 'package:flutter/material.dart';
@@ -56,12 +54,9 @@ class MessengerDiscussionPage extends ConsumerWidget {
             IconButton(
               icon: const Icon(Iconsax.info_circle),
               onPressed: () async {
-                Sheets.showAppHeightNineSheet(
-                  context: context,
-                  ref: ref,
-                  widget: DiscussionDetailsSheet(
-                    discussionAddress: discussionAddress,
-                  ),
+                Navigator.of(context).pushNamed(
+                  '/discussion_details',
+                  arguments: discussionAddress,
                 );
               },
             ),

--- a/lib/ui/views/messenger/layouts/update_discussion_page.dart
+++ b/lib/ui/views/messenger/layouts/update_discussion_page.dart
@@ -1,4 +1,6 @@
+import 'package:aewallet/application/settings/theme.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 class UpdateDiscussionPage extends ConsumerWidget {
@@ -11,6 +13,31 @@ class UpdateDiscussionPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return Scaffold();
+    final theme = ref.watch(ThemeProviders.selectedTheme);
+    final localizations = AppLocalizations.of(context)!;
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        image: DecorationImage(
+          image: AssetImage(
+            theme.background3Small!,
+          ),
+          fit: BoxFit.fitHeight,
+        ),
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: <Color>[theme.backgroundDark!, theme.background!],
+        ),
+      ),
+      child: Scaffold(
+        backgroundColor: Colors.transparent,
+        appBar: AppBar(
+          backgroundColor: Colors.transparent,
+          elevation: 0,
+          title: Text(localizations.discussionModifying),
+        ),
+      ),
+    );
   }
 }

--- a/lib/ui/views/messenger/layouts/update_discussion_page.dart
+++ b/lib/ui/views/messenger/layouts/update_discussion_page.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class UpdateDiscussionPage extends ConsumerWidget {
+  const UpdateDiscussionPage({
+    required this.discussionAddress,
+    super.key,
+  });
+
+  final String discussionAddress;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold();
+  }
+}


### PR DESCRIPTION
# Description

Discussion details is not a sheet anymore but a full page

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

## Material used:

Please delete options that are not relevant.
- iOS (Smartphone/Tablet) : iPhone 14 Pro Max

## How Has This Been Tested?

When you are in a discussion and you tap in the information button in the top right corner, you now have a full page instead of a sheet.

### Patrol

Please list here the tests created in Patrol for this pull request.

## Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

## Useful info for the reviewer:
