### PR TITLE
Display a custom message when a discussion has no messages

### DIFF
--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -572,7 +572,5 @@
   "modify": "Modify",
   "discussionModifying": "Discussion modifying",
   "admin": "Admin",
-  "next": "Next",
-  "name": "Name",
   "discussionNoMessages": "Your discussion currently has no messages."
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -573,5 +573,6 @@
   "discussionModifying": "Discussion modifying",
   "admin": "Admin",
   "next": "Next",
-  "name": "Name"
+  "name": "Name",
+  "discussionNoMessages": "Your discussion currently has no messages."
 }

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -550,5 +550,6 @@
 	"discussionModifying": "Modification de la discussion",
 	"admin": "Admin",
 	"next": "Suivant",
-	"name": "Nom"
+	"name": "Nom",
+	"discussionNoMessages": "Votre discussion ne dispose pour le moment d'aucun message"
 }

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -549,7 +549,5 @@
 	"modify": "Modifier",
 	"discussionModifying": "Modification de la discussion",
 	"admin": "Admin",
-	"next": "Suivant",
-	"name": "Nom",
 	"discussionNoMessages": "Votre discussion ne dispose pour le moment d'aucun message"
 }

--- a/lib/ui/views/messenger/layouts/messenger_discussion_page.dart
+++ b/lib/ui/views/messenger/layouts/messenger_discussion_page.dart
@@ -12,6 +12,7 @@ import 'package:aewallet/util/currency_util.dart';
 import 'package:aewallet/util/date_util.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
+import 'package:flutter_gen/gen_l10n/localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:iconsax/iconsax.dart';
 import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
@@ -329,20 +330,46 @@ class _MessageCreationFormFees extends ConsumerWidget {
   }
 }
 
-class _MessagesList extends ConsumerWidget {
+class _MessagesList extends ConsumerStatefulWidget {
   const _MessagesList({
+    super.key,
     required this.discussionAddress,
   });
   final String discussionAddress;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<_MessagesList> createState() => _MessagesListState();
+}
+
+class _MessagesListState extends ConsumerState<_MessagesList> {
+  bool hasMessages = false;
+
+  @override
+  Widget build(BuildContext context) {
     final theme = ref.watch(ThemeProviders.selectedTheme);
     final me = ref.watch(ContactProviders.getSelectedContact).valueOrNull;
-    final pagingController =
-        ref.watch(MessengerProviders.paginatedMessages(discussionAddress));
+    final pagingController = ref
+        .watch(MessengerProviders.paginatedMessages(widget.discussionAddress));
+    final localizations = AppLocalizations.of(context)!;
 
     if (me == null) return Container();
+
+    final discussion =
+        ref.watch(MessengerProviders.discussion(widget.discussionAddress));
+    setState(() {
+      hasMessages = discussion.valueOrNull?.lastMessage != null;
+    });
+
+    if (hasMessages == false) {
+      return Padding(
+        padding: const EdgeInsets.all(8),
+        child: Center(
+            child: Text(
+          localizations.discussionNoMessages,
+          textAlign: TextAlign.center,
+        )),
+      );
+    }
 
     return PagedListView(
       pagingController: pagingController,


### PR DESCRIPTION
# Description

Display of a message "Your discussion currently has no messages." when ... a discussion has no messages

Fixes # (issue)

## Type of change

- New feature (non-breaking change which adds functionality)

## Material used:

Please delete options that are not relevant.
- iOS (Smartphone/Tablet) : iPhone 14 Pro Max

## How Has This Been Tested?

Create a discussion, go on it and see the new message telling the user that there is no messages in the discussion.
Send a new message => the new message disappears and we see the message sent by the user. 

### Patrol

Please list here the tests created in Patrol for this pull request.

## Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

## Useful info for the reviewer:
