### PR TITLE
Contacts management enhanced

### DIFF
--- a/lib/application/contact.g.dart
+++ b/lib/application/contact.g.dart
@@ -1240,5 +1240,134 @@ class _IsContactExistsWithAddressProviderElement
   String? get address =>
       (origin as _IsContactExistsWithAddressProvider).address;
 }
+
+String _$getBalanceHash() => r'6db260cee3bd0bcbe6222c6da8836d88feba18db';
+
+/// See also [_getBalance].
+@ProviderFor(_getBalance)
+const _getBalanceProvider = _GetBalanceFamily();
+
+/// See also [_getBalance].
+class _GetBalanceFamily extends Family<AsyncValue<AccountBalance>> {
+  /// See also [_getBalance].
+  const _GetBalanceFamily();
+
+  /// See also [_getBalance].
+  _GetBalanceProvider call({
+    String? address,
+  }) {
+    return _GetBalanceProvider(
+      address: address,
+    );
+  }
+
+  @override
+  _GetBalanceProvider getProviderOverride(
+    covariant _GetBalanceProvider provider,
+  ) {
+    return call(
+      address: provider.address,
+    );
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'_getBalanceProvider';
+}
+
+/// See also [_getBalance].
+class _GetBalanceProvider extends AutoDisposeFutureProvider<AccountBalance> {
+  /// See also [_getBalance].
+  _GetBalanceProvider({
+    String? address,
+  }) : this._internal(
+          (ref) => _getBalance(
+            ref as _GetBalanceRef,
+            address: address,
+          ),
+          from: _getBalanceProvider,
+          name: r'_getBalanceProvider',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : _$getBalanceHash,
+          dependencies: _GetBalanceFamily._dependencies,
+          allTransitiveDependencies:
+              _GetBalanceFamily._allTransitiveDependencies,
+          address: address,
+        );
+
+  _GetBalanceProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.address,
+  }) : super.internal();
+
+  final String? address;
+
+  @override
+  Override overrideWith(
+    FutureOr<AccountBalance> Function(_GetBalanceRef provider) create,
+  ) {
+    return ProviderOverride(
+      origin: this,
+      override: _GetBalanceProvider._internal(
+        (ref) => create(ref as _GetBalanceRef),
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        address: address,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeFutureProviderElement<AccountBalance> createElement() {
+    return _GetBalanceProviderElement(this);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is _GetBalanceProvider && other.address == address;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, address.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+mixin _GetBalanceRef on AutoDisposeFutureProviderRef<AccountBalance> {
+  /// The parameter `address` of this provider.
+  String? get address;
+}
+
+class _GetBalanceProviderElement
+    extends AutoDisposeFutureProviderElement<AccountBalance>
+    with _GetBalanceRef {
+  _GetBalanceProviderElement(super.provider);
+
+  @override
+  String? get address => (origin as _GetBalanceProvider).address;
+}
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -574,5 +574,9 @@
   "admin": "Admin",
   "next": "Next",
   "name": "Name",
-  "discussionNoMessages": "Your discussion currently has no messages."
+  "discussionNoMessages": "Your discussion currently has no messages.",
+  "deleteContact": "Delete the contact",
+  "discussion": "Discussion",
+  "favorites": "Favorites",
+  "explorer": "Explorer"
 }

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -555,5 +555,5 @@
 	"deleteContact": "Supprimer le contact",
 	"discussion": "Discussion",
 	"favorites": "Favoris",
-	"explorer": "Explorer"
+	"explorer": "Explorateur"
 }

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -551,5 +551,9 @@
 	"admin": "Admin",
 	"next": "Suivant",
 	"name": "Nom",
-	"discussionNoMessages": "Votre discussion ne dispose pour le moment d'aucun message"
+	"discussionNoMessages": "Votre discussion ne dispose pour le moment d'aucun message",
+	"deleteContact": "Supprimer le contact",
+	"discussion": "Discussion",
+	"favorites": "Favoris",
+	"explorer": "Explorer"
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -219,7 +219,7 @@ class AppState extends ConsumerState<App> with WidgetsBindingObserver {
           title: 'Archethic Wallet',
           theme: ThemeData(
             dialogBackgroundColor: theme.backgroundDark,
-            primaryColor: theme.text,
+            colorSchemeSeed: theme.text,
             fontFamily: theme.secondaryFont,
             brightness: theme.brightness,
             useMaterial3: true,

--- a/lib/model/data/account_balance.dart
+++ b/lib/model/data/account_balance.dart
@@ -32,11 +32,11 @@ class AccountBalance extends HiveObject {
   @HiveField(6, defaultValue: 0)
   int nftNb;
 
-  String nativeTokenValueToString({int digits = -1}) {
+  String nativeTokenValueToString({int? digits}) {
     if (nativeTokenValue > 1000000) {
       return NumberUtil.formatThousands(nativeTokenValue.round());
     } else {
-      if (digits < 0 || nativeTokenValue == 0) {
+      if (digits == null || nativeTokenValue == 0) {
         return NumberUtil.formatThousands(nativeTokenValue);
       }
       return nativeTokenValue.toStringAsFixed(digits);

--- a/lib/model/data/account_balance.dart
+++ b/lib/model/data/account_balance.dart
@@ -32,11 +32,14 @@ class AccountBalance extends HiveObject {
   @HiveField(6, defaultValue: 0)
   int nftNb;
 
-  String nativeTokenValueToString() {
+  String nativeTokenValueToString({int digits = -1}) {
     if (nativeTokenValue > 1000000) {
       return NumberUtil.formatThousands(nativeTokenValue.round());
     } else {
-      return NumberUtil.formatThousands(nativeTokenValue);
+      if (digits < 0 || nativeTokenValue == 0) {
+        return NumberUtil.formatThousands(nativeTokenValue);
+      }
+      return nativeTokenValue.toStringAsFixed(digits);
     }
   }
 

--- a/lib/model/data/contact.dart
+++ b/lib/model/data/contact.dart
@@ -1,5 +1,6 @@
 /// SPDX-License-Identifier: AGPL-3.0-or-later
 
+import 'package:aewallet/model/data/account_balance.dart';
 // Package imports:
 import 'package:aewallet/model/data/appdb.dart';
 import 'package:hive/hive.dart';
@@ -8,7 +9,7 @@ part 'contact.g.dart';
 
 enum ContactType { keychainService, externalContact }
 
-/// Next field available : 7
+/// Next field available : 8
 @HiveType(typeId: HiveTypeIds.contact)
 class Contact extends HiveObject {
   Contact({
@@ -16,6 +17,7 @@ class Contact extends HiveObject {
     required this.address,
     required this.type,
     required this.publicKey,
+    this.balance,
     this.favorite,
   });
 
@@ -38,4 +40,8 @@ class Contact extends HiveObject {
   /// Favorite
   @HiveField(6)
   bool? favorite;
+
+  /// Balance
+  @HiveField(7)
+  AccountBalance? balance;
 }

--- a/lib/model/data/contact.g.dart
+++ b/lib/model/data/contact.g.dart
@@ -21,6 +21,7 @@ class ContactAdapter extends TypeAdapter<Contact> {
       address: fields[1] as String,
       type: fields[4] as String,
       publicKey: fields[5] == null ? '' : fields[5] as String,
+      balance: fields[7] as AccountBalance?,
       favorite: fields[6] as bool?,
     );
   }
@@ -28,7 +29,7 @@ class ContactAdapter extends TypeAdapter<Contact> {
   @override
   void write(BinaryWriter writer, Contact obj) {
     writer
-      ..writeByte(5)
+      ..writeByte(6)
       ..writeByte(0)
       ..write(obj.name)
       ..writeByte(1)
@@ -38,7 +39,9 @@ class ContactAdapter extends TypeAdapter<Contact> {
       ..writeByte(5)
       ..write(obj.publicKey)
       ..writeByte(6)
-      ..write(obj.favorite);
+      ..write(obj.favorite)
+      ..writeByte(7)
+      ..write(obj.balance);
   }
 
   @override

--- a/lib/ui/views/contacts/layouts/components/contact_list.dart
+++ b/lib/ui/views/contacts/layouts/components/contact_list.dart
@@ -35,8 +35,10 @@ class ContactList extends ConsumerWidget {
               return SingleContact(
                 contact: contactsList[index],
                 account: accounts
-                    ?.where((element) =>
-                        element.lastAddress == contactsList[index].address)
+                    ?.where(
+                      (element) =>
+                          element.lastAddress == contactsList[index].address,
+                    )
                     .firstOrNull,
               )
                   .animate(delay: (100 * index).ms)

--- a/lib/ui/views/contacts/layouts/components/contact_list.dart
+++ b/lib/ui/views/contacts/layouts/components/contact_list.dart
@@ -1,3 +1,5 @@
+import 'package:aewallet/application/account/providers.dart';
+import 'package:aewallet/application/settings/theme.dart';
 import 'package:aewallet/model/data/contact.dart';
 import 'package:aewallet/ui/views/contacts/layouts/components/single_contact.dart';
 import 'package:flutter/material.dart';
@@ -11,10 +13,17 @@ class ContactList extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final accounts = ref.watch(AccountProviders.accounts).valueOrNull;
+    final theme = ref.watch(ThemeProviders.selectedTheme);
+
     return Expanded(
       child: Stack(
         children: <Widget>[
-          ListView.builder(
+          ListView.separated(
+            separatorBuilder: (context, index) => Divider(
+              height: 2,
+              color: theme.text15,
+            ),
             physics: const AlwaysScrollableScrollPhysics(),
             padding: const EdgeInsets.only(
               top: 15,
@@ -25,6 +34,10 @@ class ContactList extends ConsumerWidget {
               // Build contact
               return SingleContact(
                 contact: contactsList[index],
+                account: accounts
+                    ?.where((element) =>
+                        element.lastAddress == contactsList[index].address)
+                    .firstOrNull,
               )
                   .animate(delay: (100 * index).ms)
                   .fadeIn(duration: 900.ms, delay: 200.ms)

--- a/lib/ui/views/contacts/layouts/components/contact_list.dart
+++ b/lib/ui/views/contacts/layouts/components/contact_list.dart
@@ -1,6 +1,7 @@
 import 'package:aewallet/application/account/providers.dart';
 import 'package:aewallet/application/contact.dart';
 import 'package:aewallet/application/settings/theme.dart';
+import 'package:aewallet/model/data/account.dart';
 import 'package:aewallet/model/data/account_balance.dart';
 import 'package:aewallet/model/data/contact.dart';
 import 'package:aewallet/ui/views/contacts/layouts/components/single_contact.dart';
@@ -34,24 +35,14 @@ class ContactList extends ConsumerWidget {
             itemCount: contactsList.length,
             itemBuilder: (BuildContext context, int index) {
               AsyncValue<AccountBalance> asyncAccountBalance;
-              final contact = contactsList[index];
-              if (contact.type == ContactType.keychainService.name) {
-                final account = accounts
-                    ?.where(
-                      (element) =>
-                          element.lastAddress == contactsList[index].address,
-                    )
-                    .firstOrNull;
-                asyncAccountBalance = AsyncValue.data(account!.balance!);
-              } else {
-                asyncAccountBalance = ref.watch(
-                    ContactProviders.getBalance(address: contact.address));
-              }
-
               // Build contact
               return SingleContact(
                 contact: contactsList[index],
-                accountBalance: asyncAccountBalance,
+                accountBalance: getAsyncAccountBalance(
+                  contactsList[index],
+                  accounts,
+                  ref,
+                ),
               )
                   .animate(delay: (100 * index).ms)
                   .fadeIn(duration: 900.ms, delay: 200.ms)
@@ -62,5 +53,22 @@ class ContactList extends ConsumerWidget {
         ],
       ),
     );
+  }
+
+  AsyncValue<AccountBalance> getAsyncAccountBalance(
+      Contact contact, List<Account>? accounts, WidgetRef ref) {
+    final account = accounts
+        ?.where(
+          (element) => element.lastAddress == contact.address,
+        )
+        .firstOrNull;
+
+    if (contact.type == ContactType.keychainService.name && account != null) {
+      return AsyncValue.data(account.balance!);
+    } else {
+      return ref.watch(
+        ContactProviders.getBalance(address: contact.address),
+      );
+    }
   }
 }

--- a/lib/ui/views/contacts/layouts/components/contact_list.dart
+++ b/lib/ui/views/contacts/layouts/components/contact_list.dart
@@ -1,5 +1,7 @@
 import 'package:aewallet/application/account/providers.dart';
+import 'package:aewallet/application/contact.dart';
 import 'package:aewallet/application/settings/theme.dart';
+import 'package:aewallet/model/data/account_balance.dart';
 import 'package:aewallet/model/data/contact.dart';
 import 'package:aewallet/ui/views/contacts/layouts/components/single_contact.dart';
 import 'package:flutter/material.dart';
@@ -31,15 +33,25 @@ class ContactList extends ConsumerWidget {
             ),
             itemCount: contactsList.length,
             itemBuilder: (BuildContext context, int index) {
-              // Build contact
-              return SingleContact(
-                contact: contactsList[index],
-                account: accounts
+              AsyncValue<AccountBalance> asyncAccountBalance;
+              final contact = contactsList[index];
+              if (contact.type == ContactType.keychainService.name) {
+                final account = accounts
                     ?.where(
                       (element) =>
                           element.lastAddress == contactsList[index].address,
                     )
-                    .firstOrNull,
+                    .firstOrNull;
+                asyncAccountBalance = AsyncValue.data(account!.balance!);
+              } else {
+                asyncAccountBalance = ref.watch(
+                    ContactProviders.getBalance(address: contact.address));
+              }
+
+              // Build contact
+              return SingleContact(
+                contact: contactsList[index],
+                accountBalance: asyncAccountBalance,
               )
                   .animate(delay: (100 * index).ms)
                   .fadeIn(duration: 900.ms, delay: 200.ms)

--- a/lib/ui/views/contacts/layouts/components/single_contact.dart
+++ b/lib/ui/views/contacts/layouts/components/single_contact.dart
@@ -1,8 +1,10 @@
 import 'package:aewallet/application/market_price.dart';
+import 'package:aewallet/application/settings/primary_currency.dart';
 import 'package:aewallet/application/settings/settings.dart';
 import 'package:aewallet/application/settings/theme.dart';
 import 'package:aewallet/model/data/account.dart';
 import 'package:aewallet/model/data/contact.dart';
+import 'package:aewallet/model/primary_currency.dart';
 import 'package:aewallet/ui/util/contact_formatters.dart';
 import 'package:aewallet/ui/util/styles.dart';
 import 'package:aewallet/ui/views/contacts/layouts/contact_detail.dart';
@@ -27,6 +29,8 @@ class SingleContact extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = ref.watch(ThemeProviders.selectedTheme);
     final settings = ref.watch(SettingsProviders.settings);
+    final primaryCurrency =
+        ref.watch(PrimaryCurrencyProviders.selectedPrimaryCurrency);
 
     final asyncFiatAmount = ref.watch(
       MarketPriceProviders.convertedToSelectedCurrency(
@@ -109,21 +113,38 @@ class SingleContact extends ConsumerWidget {
                   ),
                   if (account != null) ...[
                     if (settings.showBalances)
-                      Column(
-                        crossAxisAlignment: CrossAxisAlignment.end,
-                        children: [
-                          AutoSizeText(
-                            '${account!.balance!.nativeTokenValueToString(digits: 2)} ${account!.balance!.nativeTokenName}',
-                            style: theme.textStyleSize12W400Primary,
-                            textAlign: TextAlign.end,
-                          ),
-                          AutoSizeText(
-                            fiatAmountString,
-                            textAlign: TextAlign.end,
-                            style: theme.textStyleSize12W400Primary,
-                          ),
-                        ],
-                      )
+                      primaryCurrency.primaryCurrency ==
+                              AvailablePrimaryCurrencyEnum.native
+                          ? Column(
+                              crossAxisAlignment: CrossAxisAlignment.end,
+                              children: [
+                                AutoSizeText(
+                                  '${account!.balance!.nativeTokenValueToString(digits: 2)} ${account!.balance!.nativeTokenName}',
+                                  style: theme.textStyleSize12W400Primary,
+                                  textAlign: TextAlign.end,
+                                ),
+                                AutoSizeText(
+                                  fiatAmountString,
+                                  textAlign: TextAlign.end,
+                                  style: theme.textStyleSize12W400Primary,
+                                ),
+                              ],
+                            )
+                          : Column(
+                              crossAxisAlignment: CrossAxisAlignment.end,
+                              children: [
+                                AutoSizeText(
+                                  fiatAmountString,
+                                  textAlign: TextAlign.end,
+                                  style: theme.textStyleSize12W400Primary,
+                                ),
+                                AutoSizeText(
+                                  '${account!.balance!.nativeTokenValueToString(digits: 2)} ${account!.balance!.nativeTokenName}',
+                                  style: theme.textStyleSize12W400Primary,
+                                  textAlign: TextAlign.end,
+                                ),
+                              ],
+                            )
                     else
                       Column(
                         crossAxisAlignment: CrossAxisAlignment.end,

--- a/lib/ui/views/contacts/layouts/components/single_contact.dart
+++ b/lib/ui/views/contacts/layouts/components/single_contact.dart
@@ -1,6 +1,4 @@
-import 'package:aewallet/application/contact.dart';
 import 'package:aewallet/application/settings/theme.dart';
-import 'package:aewallet/model/data/account.dart';
 import 'package:aewallet/model/data/account_balance.dart';
 import 'package:aewallet/model/data/contact.dart';
 import 'package:aewallet/ui/util/contact_formatters.dart';
@@ -16,23 +14,16 @@ class SingleContact extends ConsumerWidget {
   const SingleContact({
     super.key,
     required this.contact,
-    required this.account,
+    required this.accountBalance,
   });
 
   final Contact contact;
-  final Account? account;
+  final AsyncValue<AccountBalance> accountBalance;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = ref.watch(ThemeProviders.selectedTheme);
 
-    AsyncValue<AccountBalance> asyncAccountBalance;
-    if (contact.type == ContactType.keychainService.name) {
-      asyncAccountBalance = AsyncValue.data(account!.balance!);
-    } else {
-      asyncAccountBalance =
-          ref.watch(ContactProviders.getBalance(address: contact.address));
-    }
     return TextButton(
       style: ButtonStyle(
         shape: MaterialStateProperty.all<RoundedRectangleBorder>(
@@ -98,7 +89,7 @@ class SingleContact extends ConsumerWidget {
                     style: theme.textStyleSize14W600Primary,
                   ),
                 ),
-                SingleContactBalance(accountBalance: asyncAccountBalance),
+                SingleContactBalance(accountBalance: accountBalance),
               ],
             ),
           ],

--- a/lib/ui/views/contacts/layouts/components/single_contact.dart
+++ b/lib/ui/views/contacts/layouts/components/single_contact.dart
@@ -107,22 +107,40 @@ class SingleContact extends ConsumerWidget {
                       style: theme.textStyleSize14W600Primary,
                     ),
                   ),
-                  if (account != null)
-                    Column(
-                      crossAxisAlignment: CrossAxisAlignment.end,
-                      children: [
-                        AutoSizeText(
-                          '${account!.balance!.nativeTokenValueToString()} ${account!.balance!.nativeTokenName}',
-                          style: theme.textStyleSize12W400Primary,
-                          textAlign: TextAlign.end,
-                        ),
-                        AutoSizeText(
-                          fiatAmountString,
-                          textAlign: TextAlign.end,
-                          style: theme.textStyleSize12W400Primary,
-                        ),
-                      ],
-                    )
+                  if (account != null) ...[
+                    if (settings.showBalances)
+                      Column(
+                        crossAxisAlignment: CrossAxisAlignment.end,
+                        children: [
+                          AutoSizeText(
+                            '${account!.balance!.nativeTokenValueToString()} ${account!.balance!.nativeTokenName}',
+                            style: theme.textStyleSize12W400Primary,
+                            textAlign: TextAlign.end,
+                          ),
+                          AutoSizeText(
+                            fiatAmountString,
+                            textAlign: TextAlign.end,
+                            style: theme.textStyleSize12W400Primary,
+                          ),
+                        ],
+                      )
+                    else
+                      Column(
+                        crossAxisAlignment: CrossAxisAlignment.end,
+                        children: [
+                          AutoSizeText(
+                            '···········',
+                            style: theme.textStyleSize12W400Primary,
+                            textAlign: TextAlign.end,
+                          ),
+                          AutoSizeText(
+                            '···········',
+                            textAlign: TextAlign.end,
+                            style: theme.textStyleSize12W400Primary,
+                          ),
+                        ],
+                      ),
+                  ],
                 ],
               ),
             ],

--- a/lib/ui/views/contacts/layouts/components/single_contact.dart
+++ b/lib/ui/views/contacts/layouts/components/single_contact.dart
@@ -1,21 +1,45 @@
+import 'package:aewallet/application/market_price.dart';
+import 'package:aewallet/application/settings/settings.dart';
 import 'package:aewallet/application/settings/theme.dart';
+import 'package:aewallet/model/data/account.dart';
 import 'package:aewallet/model/data/contact.dart';
 import 'package:aewallet/ui/util/contact_formatters.dart';
 import 'package:aewallet/ui/util/styles.dart';
 import 'package:aewallet/ui/views/contacts/layouts/contact_detail.dart';
 import 'package:aewallet/ui/widgets/components/sheet_util.dart';
+import 'package:aewallet/util/currency_util.dart';
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
 class SingleContact extends ConsumerWidget {
-  const SingleContact({super.key, required this.contact});
+  const SingleContact({
+    super.key,
+    required this.contact,
+    required this.account,
+  });
 
   final Contact contact;
+  final Account? account;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = ref.watch(ThemeProviders.selectedTheme);
+    final settings = ref.watch(SettingsProviders.settings);
+
+    final asyncFiatAmount = ref.watch(
+      MarketPriceProviders.convertedToSelectedCurrency(
+        nativeAmount: account?.balance?.nativeTokenValue ?? 0,
+      ),
+    );
+    final fiatAmountString = asyncFiatAmount.maybeWhen(
+      data: (fiatAmount) => CurrencyUtil.format(
+        settings.currency.name,
+        fiatAmount,
+      ),
+      orElse: () => '--',
+    );
 
     return TextButton(
       style: ButtonStyle(
@@ -32,79 +56,78 @@ class SingleContact extends ConsumerWidget {
           ),
         );
       },
-      child: Column(
-        children: <Widget>[
-          Divider(
-            height: 2,
-            color: theme.text15,
-          ),
-          Container(
-            padding: const EdgeInsets.symmetric(vertical: 4),
-            margin: const EdgeInsetsDirectional.only(start: 10, end: 10),
-            child: Row(
-              children: <Widget>[
-                Expanded(
-                  child: SizedBox(
-                    height: 40,
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: <Widget>[
-                        Row(
-                          children: [
-                            if (contact.type ==
-                                ContactType.keychainService.name)
-                              Icon(
-                                Symbols.account_balance_wallet,
-                                color: theme.iconDrawer,
-                                size: 25,
-                                weight: IconSize.weightM,
-                                opticalSize: IconSize.opticalSizeM,
-                                grade: IconSize.gradeM,
-                              )
-                            else
-                              Stack(
-                                alignment: Alignment.topRight,
-                                children: [
-                                  Icon(
-                                    Symbols.person,
-                                    color: theme.iconDrawer,
-                                    size: 25,
-                                    weight: IconSize.weightM,
-                                    opticalSize: IconSize.opticalSizeM,
-                                    grade: IconSize.gradeM,
-                                  ),
-                                  if (contact.favorite == true)
-                                    Icon(
-                                      Symbols.favorite,
-                                      color: theme.favoriteIconColor,
-                                      size: 12,
-                                      weight: IconSize.weightM,
-                                      opticalSize: IconSize.opticalSizeM,
-                                      grade: IconSize.gradeM,
-                                      fill: 1,
-                                    ),
-                                ],
-                              ),
-                            const SizedBox(
-                              width: 10,
-                            ),
-                            Expanded(
-                              child: Text(
-                                contact.format,
-                                style: theme.textStyleSize14W600Primary,
-                              ),
-                            ),
-                          ],
+      child: Expanded(
+        child: SizedBox(
+          height: 40,
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Row(
+                children: [
+                  if (contact.type == ContactType.keychainService.name)
+                    Icon(
+                      Symbols.account_balance_wallet,
+                      color: theme.iconDrawer,
+                      size: 25,
+                      weight: IconSize.weightM,
+                      opticalSize: IconSize.opticalSizeM,
+                      grade: IconSize.gradeM,
+                    )
+                  else
+                    Stack(
+                      alignment: Alignment.topRight,
+                      children: [
+                        Icon(
+                          Symbols.person,
+                          color: theme.iconDrawer,
+                          size: 25,
+                          weight: IconSize.weightM,
+                          opticalSize: IconSize.opticalSizeM,
+                          grade: IconSize.gradeM,
                         ),
+                        if (contact.favorite == true)
+                          Icon(
+                            Symbols.favorite,
+                            color: theme.favoriteIconColor,
+                            size: 12,
+                            weight: IconSize.weightM,
+                            opticalSize: IconSize.opticalSizeM,
+                            grade: IconSize.gradeM,
+                            fill: 1,
+                          ),
                       ],
                     ),
+                  const SizedBox(
+                    width: 10,
                   ),
-                ),
-              ],
-            ),
+                  Expanded(
+                    child: Text(
+                      contact.format,
+                      style: theme.textStyleSize14W600Primary,
+                    ),
+                  ),
+                  if (account != null)
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.end,
+                      children: [
+                        AutoSizeText(
+                          '${account!.balance!.nativeTokenValueToString()} ${account!.balance!.nativeTokenName}',
+                          style: theme.textStyleSize12W400Primary,
+                          textAlign: TextAlign.end,
+                        ),
+                        AutoSizeText(
+                          fiatAmountString,
+                          textAlign: TextAlign.end,
+                          style: theme.textStyleSize12W400Primary,
+                        ),
+                      ],
+                    )
+                ],
+              ),
+            ],
           ),
-        ],
+        ),
       ),
     );
   }

--- a/lib/ui/views/contacts/layouts/components/single_contact.dart
+++ b/lib/ui/views/contacts/layouts/components/single_contact.dart
@@ -89,7 +89,10 @@ class SingleContact extends ConsumerWidget {
                     style: theme.textStyleSize14W600Primary,
                   ),
                 ),
-                SingleContactBalance(accountBalance: accountBalance),
+                SingleContactBalance(
+                  contact: contact,
+                  accountBalance: accountBalance,
+                ),
               ],
             ),
           ],

--- a/lib/ui/views/contacts/layouts/components/single_contact.dart
+++ b/lib/ui/views/contacts/layouts/components/single_contact.dart
@@ -1,16 +1,13 @@
-import 'package:aewallet/application/market_price.dart';
-import 'package:aewallet/application/settings/primary_currency.dart';
-import 'package:aewallet/application/settings/settings.dart';
+import 'package:aewallet/application/contact.dart';
 import 'package:aewallet/application/settings/theme.dart';
 import 'package:aewallet/model/data/account.dart';
+import 'package:aewallet/model/data/account_balance.dart';
 import 'package:aewallet/model/data/contact.dart';
-import 'package:aewallet/model/primary_currency.dart';
 import 'package:aewallet/ui/util/contact_formatters.dart';
 import 'package:aewallet/ui/util/styles.dart';
+import 'package:aewallet/ui/views/contacts/layouts/components/single_contact_balance.dart';
 import 'package:aewallet/ui/views/contacts/layouts/contact_detail.dart';
 import 'package:aewallet/ui/widgets/components/sheet_util.dart';
-import 'package:aewallet/util/currency_util.dart';
-import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
@@ -28,23 +25,14 @@ class SingleContact extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = ref.watch(ThemeProviders.selectedTheme);
-    final settings = ref.watch(SettingsProviders.settings);
-    final primaryCurrency =
-        ref.watch(PrimaryCurrencyProviders.selectedPrimaryCurrency);
 
-    final asyncFiatAmount = ref.watch(
-      MarketPriceProviders.convertedToSelectedCurrency(
-        nativeAmount: account?.balance?.nativeTokenValue ?? 0,
-      ),
-    );
-    final fiatAmountString = asyncFiatAmount.maybeWhen(
-      data: (fiatAmount) => CurrencyUtil.format(
-        settings.currency.name,
-        fiatAmount,
-      ),
-      orElse: () => '--',
-    );
-
+    AsyncValue<AccountBalance> asyncAccountBalance;
+    if (contact.type == ContactType.keychainService.name) {
+      asyncAccountBalance = AsyncValue.data(account!.balance!);
+    } else {
+      asyncAccountBalance =
+          ref.watch(ContactProviders.getBalance(address: contact.address));
+    }
     return TextButton(
       style: ButtonStyle(
         shape: MaterialStateProperty.all<RoundedRectangleBorder>(
@@ -60,112 +48,60 @@ class SingleContact extends ConsumerWidget {
           ),
         );
       },
-      child: Expanded(
-        child: SizedBox(
-          height: 40,
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: <Widget>[
-              Row(
-                children: [
-                  if (contact.type == ContactType.keychainService.name)
-                    Icon(
-                      Symbols.account_balance_wallet,
-                      color: theme.iconDrawer,
-                      size: 25,
-                      weight: IconSize.weightM,
-                      opticalSize: IconSize.opticalSizeM,
-                      grade: IconSize.gradeM,
-                    )
-                  else
-                    Stack(
-                      alignment: Alignment.topRight,
-                      children: [
+      child: SizedBox(
+        height: 40,
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Row(
+              children: [
+                if (contact.type == ContactType.keychainService.name)
+                  Icon(
+                    Symbols.account_balance_wallet,
+                    color: theme.iconDrawer,
+                    size: 25,
+                    weight: IconSize.weightM,
+                    opticalSize: IconSize.opticalSizeM,
+                    grade: IconSize.gradeM,
+                  )
+                else
+                  Stack(
+                    alignment: Alignment.topRight,
+                    children: [
+                      Icon(
+                        Symbols.person,
+                        color: theme.iconDrawer,
+                        size: 25,
+                        weight: IconSize.weightM,
+                        opticalSize: IconSize.opticalSizeM,
+                        grade: IconSize.gradeM,
+                      ),
+                      if (contact.favorite == true)
                         Icon(
-                          Symbols.person,
-                          color: theme.iconDrawer,
-                          size: 25,
+                          Symbols.favorite,
+                          color: theme.favoriteIconColor,
+                          size: 12,
                           weight: IconSize.weightM,
                           opticalSize: IconSize.opticalSizeM,
                           grade: IconSize.gradeM,
+                          fill: 1,
                         ),
-                        if (contact.favorite == true)
-                          Icon(
-                            Symbols.favorite,
-                            color: theme.favoriteIconColor,
-                            size: 12,
-                            weight: IconSize.weightM,
-                            opticalSize: IconSize.opticalSizeM,
-                            grade: IconSize.gradeM,
-                            fill: 1,
-                          ),
-                      ],
-                    ),
-                  const SizedBox(
-                    width: 10,
+                    ],
                   ),
-                  Expanded(
-                    child: Text(
-                      contact.format,
-                      style: theme.textStyleSize14W600Primary,
-                    ),
+                const SizedBox(
+                  width: 10,
+                ),
+                Expanded(
+                  child: Text(
+                    contact.format,
+                    style: theme.textStyleSize14W600Primary,
                   ),
-                  if (account != null) ...[
-                    if (settings.showBalances)
-                      primaryCurrency.primaryCurrency ==
-                              AvailablePrimaryCurrencyEnum.native
-                          ? Column(
-                              crossAxisAlignment: CrossAxisAlignment.end,
-                              children: [
-                                AutoSizeText(
-                                  '${account!.balance!.nativeTokenValueToString(digits: 2)} ${account!.balance!.nativeTokenName}',
-                                  style: theme.textStyleSize12W400Primary,
-                                  textAlign: TextAlign.end,
-                                ),
-                                AutoSizeText(
-                                  fiatAmountString,
-                                  textAlign: TextAlign.end,
-                                  style: theme.textStyleSize12W400Primary,
-                                ),
-                              ],
-                            )
-                          : Column(
-                              crossAxisAlignment: CrossAxisAlignment.end,
-                              children: [
-                                AutoSizeText(
-                                  fiatAmountString,
-                                  textAlign: TextAlign.end,
-                                  style: theme.textStyleSize12W400Primary,
-                                ),
-                                AutoSizeText(
-                                  '${account!.balance!.nativeTokenValueToString(digits: 2)} ${account!.balance!.nativeTokenName}',
-                                  style: theme.textStyleSize12W400Primary,
-                                  textAlign: TextAlign.end,
-                                ),
-                              ],
-                            )
-                    else
-                      Column(
-                        crossAxisAlignment: CrossAxisAlignment.end,
-                        children: [
-                          AutoSizeText(
-                            '···········',
-                            style: theme.textStyleSize12W400Primary,
-                            textAlign: TextAlign.end,
-                          ),
-                          AutoSizeText(
-                            '···········',
-                            textAlign: TextAlign.end,
-                            style: theme.textStyleSize12W400Primary,
-                          ),
-                        ],
-                      ),
-                  ],
-                ],
-              ),
-            ],
-          ),
+                ),
+                SingleContactBalance(accountBalance: asyncAccountBalance),
+              ],
+            ),
+          ],
         ),
       ),
     );

--- a/lib/ui/views/contacts/layouts/components/single_contact.dart
+++ b/lib/ui/views/contacts/layouts/components/single_contact.dart
@@ -113,7 +113,7 @@ class SingleContact extends ConsumerWidget {
                         crossAxisAlignment: CrossAxisAlignment.end,
                         children: [
                           AutoSizeText(
-                            '${account!.balance!.nativeTokenValueToString()} ${account!.balance!.nativeTokenName}',
+                            '${account!.balance!.nativeTokenValueToString(digits: 2)} ${account!.balance!.nativeTokenName}',
                             style: theme.textStyleSize12W400Primary,
                             textAlign: TextAlign.end,
                           ),

--- a/lib/ui/views/contacts/layouts/components/single_contact_balance.dart
+++ b/lib/ui/views/contacts/layouts/components/single_contact_balance.dart
@@ -1,0 +1,102 @@
+import 'package:aewallet/application/market_price.dart';
+import 'package:aewallet/application/settings/primary_currency.dart';
+import 'package:aewallet/application/settings/settings.dart';
+import 'package:aewallet/application/settings/theme.dart';
+import 'package:aewallet/model/data/account_balance.dart';
+import 'package:aewallet/model/primary_currency.dart';
+import 'package:aewallet/ui/util/styles.dart';
+import 'package:aewallet/util/currency_util.dart';
+import 'package:auto_size_text/auto_size_text.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class SingleContactBalance extends ConsumerWidget {
+  const SingleContactBalance({
+    super.key,
+    required this.accountBalance,
+  });
+
+  final AsyncValue<AccountBalance> accountBalance;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return accountBalance.when(
+      data: (accountBalance) {
+        final theme = ref.watch(ThemeProviders.selectedTheme);
+        final settings = ref.watch(SettingsProviders.settings);
+        final primaryCurrency =
+            ref.watch(PrimaryCurrencyProviders.selectedPrimaryCurrency);
+
+        final asyncFiatAmount = ref.watch(
+          MarketPriceProviders.convertedToSelectedCurrency(
+            nativeAmount: accountBalance.nativeTokenValue,
+          ),
+        );
+        final fiatAmountString = asyncFiatAmount.maybeWhen(
+          data: (fiatAmount) => CurrencyUtil.format(
+            settings.currency.name,
+            fiatAmount,
+          ),
+          orElse: () => '--',
+        );
+
+        if (settings.showBalances) {
+          return primaryCurrency.primaryCurrency ==
+                  AvailablePrimaryCurrencyEnum.native
+              ? Column(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: [
+                    AutoSizeText(
+                      '${accountBalance.nativeTokenValueToString(digits: 2)} ${accountBalance.nativeTokenName}',
+                      style: theme.textStyleSize12W400Primary,
+                      textAlign: TextAlign.end,
+                    ),
+                    AutoSizeText(
+                      fiatAmountString,
+                      textAlign: TextAlign.end,
+                      style: theme.textStyleSize12W400Primary,
+                    ),
+                  ],
+                )
+              : Column(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: [
+                    AutoSizeText(
+                      fiatAmountString,
+                      textAlign: TextAlign.end,
+                      style: theme.textStyleSize12W400Primary,
+                    ),
+                    AutoSizeText(
+                      '${accountBalance.nativeTokenValueToString(digits: 2)} ${accountBalance.nativeTokenName}',
+                      style: theme.textStyleSize12W400Primary,
+                      textAlign: TextAlign.end,
+                    ),
+                  ],
+                );
+        } else {
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              AutoSizeText(
+                '···········',
+                style: theme.textStyleSize12W400Primary,
+                textAlign: TextAlign.end,
+              ),
+              AutoSizeText(
+                '···········',
+                textAlign: TextAlign.end,
+                style: theme.textStyleSize12W400Primary,
+              ),
+            ],
+          );
+        }
+      },
+      error: (error, stack) => const Column(
+        children: [SizedBox()],
+      ),
+      loading: () => const Column(
+        children: [SizedBox()],
+      ),
+    );
+  }
+}

--- a/lib/ui/views/contacts/layouts/components/single_contact_balance.dart
+++ b/lib/ui/views/contacts/layouts/components/single_contact_balance.dart
@@ -1,8 +1,10 @@
+import 'package:aewallet/application/contact.dart';
 import 'package:aewallet/application/market_price.dart';
 import 'package:aewallet/application/settings/primary_currency.dart';
 import 'package:aewallet/application/settings/settings.dart';
 import 'package:aewallet/application/settings/theme.dart';
 import 'package:aewallet/model/data/account_balance.dart';
+import 'package:aewallet/model/data/contact.dart';
 import 'package:aewallet/model/primary_currency.dart';
 import 'package:aewallet/ui/util/styles.dart';
 import 'package:aewallet/util/currency_util.dart';
@@ -13,15 +15,21 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 class SingleContactBalance extends ConsumerWidget {
   const SingleContactBalance({
     super.key,
+    required this.contact,
     required this.accountBalance,
   });
 
+  final Contact contact;
   final AsyncValue<AccountBalance> accountBalance;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return accountBalance.when(
       data: (accountBalance) {
+        ContactProviders.saveContact(
+          contact: contact,
+        );
+
         final theme = ref.watch(ThemeProviders.selectedTheme);
         final settings = ref.watch(SettingsProviders.settings);
         final primaryCurrency =

--- a/lib/ui/views/contacts/layouts/contact_detail.dart
+++ b/lib/ui/views/contacts/layouts/contact_detail.dart
@@ -86,6 +86,7 @@ class ContactDetail extends ConsumerWidget {
                       Expanded(
                         flex: 2,
                         child: SingleContactBalance(
+                          contact: contact,
                           accountBalance: asyncAccountBalance,
                         ),
                       ),

--- a/lib/ui/views/contacts/layouts/contact_detail.dart
+++ b/lib/ui/views/contacts/layouts/contact_detail.dart
@@ -76,12 +76,14 @@ class ContactDetail extends ConsumerWidget {
                     mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                     children: <Widget>[
                       const Expanded(child: SizedBox()),
-                      AutoSizeText(
-                        contact.format,
-                        style: theme.textStyleSize24W700EquinoxPrimary,
-                        textAlign: TextAlign.center,
-                        maxLines: 1,
-                        stepGranularity: 0.1,
+                      Flexible(
+                        child: AutoSizeText(
+                          contact.format,
+                          style: theme.textStyleSize24W700EquinoxPrimary,
+                          textAlign: TextAlign.center,
+                          maxLines: 1,
+                          stepGranularity: 0.1,
+                        ),
                       ),
                       if (account != null) ...[
                         if (settings.showBalances)
@@ -90,7 +92,7 @@ class ContactDetail extends ConsumerWidget {
                               crossAxisAlignment: CrossAxisAlignment.end,
                               children: [
                                 AutoSizeText(
-                                  '${account.balance!.nativeTokenValueToString()} ${account!.balance!.nativeTokenName}',
+                                  '${account.balance!.nativeTokenValueToString(digits: 2)} ${account!.balance!.nativeTokenName}',
                                   style: theme.textStyleSize12W400Primary,
                                   textAlign: TextAlign.end,
                                 ),

--- a/lib/ui/views/contacts/layouts/contact_detail.dart
+++ b/lib/ui/views/contacts/layouts/contact_detail.dart
@@ -252,7 +252,6 @@ class _ContactDetailActions extends ConsumerWidget {
   const _ContactDetailActions({
     required this.contact,
     this.readOnly = false,
-    super.key,
   });
 
   final Contact contact;

--- a/lib/ui/views/contacts/layouts/contact_detail.dart
+++ b/lib/ui/views/contacts/layouts/contact_detail.dart
@@ -3,13 +3,12 @@ import 'package:aewallet/application/account/providers.dart';
 import 'package:aewallet/application/contact.dart';
 import 'package:aewallet/application/settings/settings.dart';
 import 'package:aewallet/application/settings/theme.dart';
+import 'package:aewallet/domain/repositories/features_flags.dart';
 import 'package:aewallet/model/data/contact.dart';
 import 'package:aewallet/ui/util/contact_formatters.dart';
-import 'package:aewallet/ui/util/dimens.dart';
 import 'package:aewallet/ui/util/styles.dart';
 import 'package:aewallet/ui/util/ui_util.dart';
 import 'package:aewallet/ui/views/contacts/layouts/components/contact_detail_tab.dart';
-import 'package:aewallet/ui/widgets/components/app_button_tiny.dart';
 import 'package:aewallet/ui/widgets/components/dialog.dart';
 import 'package:aewallet/util/get_it_instance.dart';
 import 'package:aewallet/util/haptic_util.dart';
@@ -24,186 +23,53 @@ import 'package:material_symbols_icons/symbols.dart';
 class ContactDetail extends ConsumerWidget {
   const ContactDetail({
     required this.contact,
-    this.editMode = true,
+    this.readOnly = false,
     super.key,
   });
 
   final Contact contact;
-  final bool editMode;
+  final bool readOnly;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final localizations = AppLocalizations.of(context)!;
     final theme = ref.watch(ThemeProviders.selectedTheme);
     final preferences = ref.watch(SettingsProviders.settings);
-    final _contact = ref.watch(
-      ContactProviders.getContactWithName(
-        contact.format,
-      ),
-    );
 
     return SafeArea(
-      minimum: EdgeInsets.only(
-        bottom: MediaQuery.of(context).size.height * 0.035,
-      ),
       child: Column(
         children: <Widget>[
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: <Widget>[
-              Container(
-                width: 50,
-                height: 50,
-                margin: const EdgeInsetsDirectional.only(
-                  top: 10,
-                  start: 10,
-                ),
-                child: contact.type == ContactType.keychainService.name ||
-                        editMode == false
-                    ? const SizedBox()
-                    : TextButton(
-                        style: ButtonStyle(
-                          shape:
-                              MaterialStateProperty.all<RoundedRectangleBorder>(
-                            const RoundedRectangleBorder(),
-                          ),
-                        ),
-                        onPressed: () {
-                          sl.get<HapticUtil>().feedback(
-                                FeedbackType.light,
-                                preferences.activeVibrations,
-                              );
-                          AppDialogs.showConfirmDialog(
-                            context,
-                            ref,
-                            localizations.removeContact,
-                            localizations.removeContactConfirmation.replaceAll(
-                              '%1',
-                              contact.format,
-                            ),
-                            localizations.yes,
-                            () {
-                              ref.read(
-                                ContactProviders.deleteContact(
-                                  contact: contact,
-                                ),
-                              );
-
-                              ref
-                                  .read(
-                                    AccountProviders.selectedAccount.notifier,
-                                  )
-                                  .refreshRecentTransactions();
-                              UIUtil.showSnackbar(
-                                localizations.contactRemoved.replaceAll(
-                                  '%1',
-                                  contact.format,
-                                ),
-                                context,
-                                ref,
-                                theme.text!,
-                                theme.snackBarShadow!,
-                              );
-                              Navigator.of(context).pop();
-                            },
-                            cancelText: localizations.no,
-                          );
-                        },
-                        child: Icon(
-                          Symbols.delete,
-                          size: 24,
-                          color: theme.text,
-                          weight: IconSize.weightM,
-                          opticalSize: IconSize.opticalSizeM,
-                          grade: IconSize.gradeM,
-                        ),
-                      ),
-              ),
-              Container(
-                margin: const EdgeInsets.only(top: 25),
-                constraints: BoxConstraints(
-                  maxWidth: MediaQuery.of(context).size.width - 140,
-                ),
-                child: Column(
-                  children: <Widget>[
-                    AutoSizeText(
-                      contact.format,
-                      style: theme.textStyleSize24W700EquinoxPrimary,
-                      textAlign: TextAlign.center,
-                      maxLines: 1,
-                      stepGranularity: 0.1,
-                    ),
-                  ],
-                ),
-              ),
-              if (contact.type == ContactType.keychainService.name ||
-                  editMode == false)
-                const SizedBox(
-                  width: 50,
-                  height: 50,
-                )
-              else
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
                 Container(
-                  width: 50,
-                  height: 50,
-                  margin: const EdgeInsetsDirectional.only(
-                    top: 10,
-                    end: 10,
+                  margin: const EdgeInsets.only(top: 25, bottom: 15),
+                  constraints: BoxConstraints(
+                    maxWidth: MediaQuery.of(context).size.width - 140,
                   ),
-                  child: InkWell(
-                    onTap: () async {
-                      sl.get<HapticUtil>().feedback(
-                            FeedbackType.light,
-                            preferences.activeVibrations,
-                          );
-                      final updatedContact = contact;
-                      if (contact.favorite == null) {
-                        updatedContact.favorite = true;
-                      } else {
-                        updatedContact.favorite = !contact.favorite!;
-                      }
-
-                      ref.read(
-                        ContactProviders.saveContact(
-                          contact: updatedContact,
-                        ),
-                      );
-                    },
-                    child: _contact.maybeWhen(
-                      data: (data) {
-                        return data.favorite == null || data.favorite == false
-                            ? Icon(
-                                Symbols.favorite_border,
-                                color: theme.favoriteIconColor,
-                                size: 26,
-                                weight: IconSize.weightM,
-                                opticalSize: IconSize.opticalSizeM,
-                                grade: IconSize.gradeM,
-                              )
-                            : Icon(
-                                Symbols.favorite,
-                                color: theme.favoriteIconColor,
-                                size: 26,
-                                weight: IconSize.weightM,
-                                opticalSize: IconSize.opticalSizeM,
-                                grade: IconSize.gradeM,
-                                fill: 1,
-                              );
-                      },
-                      loading: () => const SizedBox(),
-                      orElse: () => const SizedBox(),
-                    ),
+                  child: Column(
+                    children: <Widget>[
+                      AutoSizeText(
+                        contact.format,
+                        style: theme.textStyleSize24W700EquinoxPrimary,
+                        textAlign: TextAlign.center,
+                        maxLines: 1,
+                        stepGranularity: 0.1,
+                      ),
+                    ],
                   ),
                 ),
-            ],
+                _ContactDetailActions(contact: contact, readOnly: readOnly),
+              ],
+            ),
           ),
           Expanded(
             child: Container(
-              padding: const EdgeInsets.all(8),
+              padding: const EdgeInsets.only(top: 8, right: 8, left: 8),
               color: Colors.transparent,
               width: MediaQuery.of(context).size.width,
-              height: 200,
               child: ContainedTabBarView(
                 tabBarProperties: TabBarProperties(
                   indicatorColor: theme.backgroundDarkest,
@@ -242,29 +108,179 @@ class ContactDetail extends ConsumerWidget {
               ),
             ),
           ),
-          Column(
-            children: <Widget>[
-              Row(
-                children: <Widget>[
-                  AppButtonTinyConnectivity(
-                    localizations.viewExplorer,
-                    Dimens.buttonBottomDimens,
-                    icon: Symbols.more_horiz,
-                    key: const Key('viewExplorer'),
-                    onPressed: () async {
-                      UIUtil.showWebview(
-                        context,
-                        '${ref.read(SettingsProviders.settings).network.getLink()}/explorer/transaction/${contact.address}',
-                        '',
-                      );
-                    },
+          Visibility(
+            visible: contact.type != ContactType.keychainService.name &&
+                readOnly == false,
+            child: Column(
+              children: [
+                TextButton(
+                  key: const Key('removeContact'),
+                  onPressed: () {
+                    sl.get<HapticUtil>().feedback(
+                          FeedbackType.light,
+                          preferences.activeVibrations,
+                        );
+                    AppDialogs.showConfirmDialog(
+                      context,
+                      ref,
+                      localizations.removeContact,
+                      localizations.removeContactConfirmation.replaceAll(
+                        '%1',
+                        contact.format,
+                      ),
+                      localizations.yes,
+                      () {
+                        ref.read(
+                          ContactProviders.deleteContact(
+                            contact: contact,
+                          ),
+                        );
+
+                        ref
+                            .read(
+                              AccountProviders.selectedAccount.notifier,
+                            )
+                            .refreshRecentTransactions();
+                        UIUtil.showSnackbar(
+                          localizations.contactRemoved.replaceAll(
+                            '%1',
+                            contact.format,
+                          ),
+                          context,
+                          ref,
+                          theme.text!,
+                          theme.snackBarShadow!,
+                        );
+                        Navigator.of(context).pop();
+                      },
+                      cancelText: localizations.no,
+                    );
+                  },
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Icon(
+                        Symbols.delete,
+                        color: theme.textStyleSize14W600EquinoxPrimaryRed.color,
+                      ),
+                      const SizedBox(
+                        width: 8,
+                      ),
+                      Text(
+                        localizations.deleteContact,
+                        style: theme.textStyleSize14W600EquinoxPrimaryRed,
+                      ),
+                    ],
                   ),
-                ],
-              ),
-            ],
+                ),
+              ],
+            ),
           ),
         ],
       ),
+    );
+  }
+}
+
+class _ContactDetailActions extends ConsumerWidget {
+  const _ContactDetailActions({
+    required this.contact,
+    this.readOnly = false,
+    super.key,
+  });
+
+  final Contact contact;
+  final bool readOnly;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final localizations = AppLocalizations.of(context)!;
+    final preferences = ref.watch(SettingsProviders.settings);
+    final _contact = ref.watch(
+      ContactProviders.getContactWithName(
+        contact.format,
+      ),
+    );
+    final theme = ref.watch(ThemeProviders.selectedTheme);
+
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+      children: [
+        if (contact.type != ContactType.keychainService.name &&
+            readOnly == false) ...[
+          IconButton(
+            key: const Key('favorite'),
+            onPressed: () {
+              sl.get<HapticUtil>().feedback(
+                    FeedbackType.light,
+                    preferences.activeVibrations,
+                  );
+              final updatedContact = contact;
+              if (contact.favorite == null) {
+                updatedContact.favorite = true;
+              } else {
+                updatedContact.favorite = !contact.favorite!;
+              }
+
+              ref.read(
+                ContactProviders.saveContact(
+                  contact: updatedContact,
+                ),
+              );
+            },
+            icon: Column(
+              children: [
+                _contact.maybeWhen(
+                  data: (data) {
+                    return Icon(
+                      Symbols.favorite,
+                      color: theme.favoriteIconColor,
+                      fill: data.favorite == null || data.favorite == false
+                          ? 1
+                          : 0,
+                    );
+                  },
+                  orElse: () => Icon(
+                    Symbols.favorite,
+                    color: theme.favoriteIconColor,
+                  ),
+                ),
+                const SizedBox(
+                  height: 4,
+                ),
+                Text(localizations.favorites),
+              ],
+            ),
+          ),
+          if (FeatureFlags.messagingActive)
+            IconButton(
+              key: const Key('newDiscussion'),
+              onPressed: () {},
+              icon: Column(
+                children: [
+                  const Icon(Symbols.edit_square),
+                  const SizedBox(
+                    height: 4,
+                  ),
+                  Text(localizations.discussion),
+                ],
+              ),
+            ),
+        ],
+        IconButton(
+          key: const Key('viewExplorer'),
+          onPressed: () {},
+          icon: Column(
+            children: [
+              const Icon(Symbols.open_in_new),
+              const SizedBox(
+                height: 4,
+              ),
+              Text(localizations.explorer),
+            ],
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/ui/views/contacts/layouts/contact_detail.dart
+++ b/lib/ui/views/contacts/layouts/contact_detail.dart
@@ -92,7 +92,7 @@ class ContactDetail extends ConsumerWidget {
                               crossAxisAlignment: CrossAxisAlignment.end,
                               children: [
                                 AutoSizeText(
-                                  '${account.balance!.nativeTokenValueToString(digits: 2)} ${account!.balance!.nativeTokenName}',
+                                  '${account.balance!.nativeTokenValueToString(digits: 2)} ${account.balance!.nativeTokenName}',
                                   style: theme.textStyleSize12W400Primary,
                                   textAlign: TextAlign.end,
                                 ),

--- a/lib/ui/views/intro/intro_import_seed.dart
+++ b/lib/ui/views/intro/intro_import_seed.dart
@@ -336,7 +336,7 @@ class _IntroImportSeedState extends ConsumerState<IntroImportSeedPage>
                               children: <Widget>[
                                 GridView.count(
                                   physics: const NeverScrollableScrollPhysics(),
-                                  childAspectRatio: 1 / 0.6,
+                                  childAspectRatio: 1 / 0.62,
                                   shrinkWrap: true,
                                   crossAxisCount: 4,
                                   children: List.generate(24, (index) {
@@ -447,6 +447,9 @@ class _IntroImportSeedState extends ConsumerState<IntroImportSeedPage>
                           ],
                         ),
                       ),
+                    ),
+                    const SizedBox(
+                      height: 20,
                     ),
                     Row(
                       mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/ui/views/main/components/main_appbar.dart
+++ b/lib/ui/views/main/components/main_appbar.dart
@@ -112,7 +112,8 @@ class MainAppBar extends ConsumerWidget implements PreferredSizeWidget {
                     );
                   },
                 )
-              else if (preferences.mainScreenCurrentPage == 1 ||
+              else if (preferences.mainScreenCurrentPage == 0 ||
+                  preferences.mainScreenCurrentPage == 1 ||
                   preferences.mainScreenCurrentPage == 2)
                 preferences.showBalances
                     ? const MainAppBarIconBalanceShowed()

--- a/lib/ui/views/messenger/bloc/create_discussion_form.dart
+++ b/lib/ui/views/messenger/bloc/create_discussion_form.dart
@@ -48,6 +48,12 @@ class CreateDiscussionFormNotifier
     );
   }
 
+  void removeAllMembers() {
+    state = state.copyWith(
+      members: [],
+    );
+  }
+
   void addAdmin(Contact member) {
     if (state.admins.contains(member)) return;
     state = state.copyWith(

--- a/lib/ui/views/messenger/layouts/create_discussion_sheet.dart
+++ b/lib/ui/views/messenger/layouts/create_discussion_sheet.dart
@@ -182,7 +182,7 @@ class CreateDiscussionSheetState extends ConsumerState<CreateDiscussionSheet> {
                                               context: context,
                                               ref: ref,
                                               widget:
-                                                  const CreateDiscussionValidationSheet(),
+                                                  CreateDiscussionValidationSheet(),
                                               onDisposed: () {
                                                 formNotifier.resetValidation();
                                               },

--- a/lib/ui/views/messenger/layouts/create_discussion_validation_sheet.dart
+++ b/lib/ui/views/messenger/layouts/create_discussion_validation_sheet.dart
@@ -16,6 +16,7 @@ import 'package:flutter_gen/gen_l10n/localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
+// ignore: must_be_immutable
 class CreateDiscussionValidationSheet extends ConsumerStatefulWidget {
   CreateDiscussionValidationSheet({
     super.key,

--- a/lib/ui/views/messenger/layouts/create_discussion_validation_sheet.dart
+++ b/lib/ui/views/messenger/layouts/create_discussion_validation_sheet.dart
@@ -135,7 +135,7 @@ class _CreateDiscussionValidationSheetState
                               ref: ref,
                               widget: ContactDetail(
                                 contact: formState.membersList[index],
-                                editMode: false,
+                                readOnly: true,
                               ),
                             );
                           },

--- a/lib/ui/views/messenger/layouts/create_discussion_validation_sheet.dart
+++ b/lib/ui/views/messenger/layouts/create_discussion_validation_sheet.dart
@@ -17,9 +17,12 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
 class CreateDiscussionValidationSheet extends ConsumerStatefulWidget {
-  const CreateDiscussionValidationSheet({
+  CreateDiscussionValidationSheet({
     super.key,
+    this.discussionCreationSuccess,
   });
+
+  Function? discussionCreationSuccess;
 
   @override
   ConsumerState<CreateDiscussionValidationSheet> createState() =>
@@ -190,6 +193,7 @@ class _CreateDiscussionValidationSheetState
                                   .pop(); // create discussion validation sheet
                               Navigator.of(context)
                                   .pop(); // create discussion sheet
+                              widget.discussionCreationSuccess?.call();
                             },
                             failure: (failure) {
                               UIUtil.showSnackbar(

--- a/lib/ui/widgets/components/dialog.dart
+++ b/lib/ui/widgets/components/dialog.dart
@@ -42,51 +42,65 @@ class AppDialogs {
               color: theme.text45!,
             ),
           ),
-          content: RichText(
-            text: TextSpan(
-              text: '',
-              children: <InlineSpan>[
-                TextSpan(
-                  text: content,
-                  style: theme.textStyleSize12W100Primary,
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              RichText(
+                text: TextSpan(
+                  text: '',
+                  children: <InlineSpan>[
+                    TextSpan(
+                      text: content,
+                      style: theme.textStyleSize12W100Primary,
+                    ),
+                    if (additionalContent != null)
+                      TextSpan(
+                        text: '\n\n$additionalContent',
+                        style: additionalContentStyle ??
+                            theme.textStyleSize12W100Primary,
+                      ),
+                  ],
                 ),
-                if (additionalContent != null)
-                  TextSpan(
-                    text: '\n\n$additionalContent',
-                    style: additionalContentStyle ??
-                        theme.textStyleSize12W100Primary,
+              ),
+              const SizedBox(
+                height: 20,
+              ),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  _AppDialogsButton(
+                    key: const Key('cancelButton'),
+                    textButton: cancelText!,
+                    onPressed: () {
+                      sl.get<HapticUtil>().feedback(
+                            FeedbackType.light,
+                            preferences.activeVibrations,
+                          );
+                      Navigator.of(context).pop();
+                      if (cancelAction != null) {
+                        cancelAction();
+                      }
+                    },
                   ),
-              ],
-            ),
+                  const SizedBox(
+                    width: 10,
+                  ),
+                  _AppDialogsButton(
+                    key: const Key('yesButton'),
+                    textButton: buttonText,
+                    onPressed: () {
+                      sl.get<HapticUtil>().feedback(
+                            FeedbackType.light,
+                            preferences.activeVibrations,
+                          );
+                      Navigator.of(context).pop();
+                      onPressed();
+                    },
+                  ),
+                ],
+              ),
+            ],
           ),
-          actions: <Widget>[
-            _AppDialogsButton(
-              key: const Key('cancelButton'),
-              textButton: cancelText!,
-              onPressed: () {
-                sl.get<HapticUtil>().feedback(
-                      FeedbackType.light,
-                      preferences.activeVibrations,
-                    );
-                Navigator.of(context).pop();
-                if (cancelAction != null) {
-                  cancelAction();
-                }
-              },
-            ),
-            _AppDialogsButton(
-              key: const Key('yesButton'),
-              textButton: buttonText,
-              onPressed: () {
-                sl.get<HapticUtil>().feedback(
-                      FeedbackType.light,
-                      preferences.activeVibrations,
-                    );
-                Navigator.of(context).pop();
-                onPressed();
-              },
-            ),
-          ],
         );
       },
     );
@@ -162,9 +176,10 @@ class _AppDialogsButton extends ConsumerWidget {
     return TextButton(
       onPressed: onPressed,
       child: Container(
-        constraints: const BoxConstraints(maxWidth: 100),
+        constraints: const BoxConstraints(maxWidth: 90),
         child: Text(
           textButton,
+          textAlign: TextAlign.center,
           style: theme.textStyleSize12W400Primary,
         ),
       ),


### PR DESCRIPTION
# Description

Contacts enhancement

Fixes #796 

## Type of change

- New feature (non-breaking change which adds functionality)

## Material used:

Please delete options that are not relevant.
- iOS (Smartphone/Tablet) : iPhone 14 Pro Max

## How Has This Been Tested?

Go into the contacts tab and see directly the contacts balance. Possibility to hide the balance on the top right, like the other screens.
In the detail of a contact, we can now :
- See his balance
- Create a new discussion
- New design : Remove the contact, add it to the favorites, or view the block chain info from the explorer

@redDwarf03 I didn't make the second point (swippable item for the list), because 1. the task was taking me too damn time but also because I think that this is not the right thing to do : for example in the contact app on iOS you cannot delete a contact otherwise than go into his detail (no swipe possible from the contact home screen)

### Patrol

Please list here the tests created in Patrol for this pull request.

## Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

## Useful info for the reviewer:
