### PR TITLE
fix issue with TabNavigation

### DIFF
--- a/lib/ui/views/accounts/layouts/components/account_list_item.dart
+++ b/lib/ui/views/accounts/layouts/components/account_list_item.dart
@@ -13,6 +13,7 @@ import 'package:aewallet/ui/util/service_type_formatters.dart';
 import 'package:aewallet/ui/util/styles.dart';
 import 'package:aewallet/ui/views/accounts/layouts/components/account_list_item_token_info.dart';
 import 'package:aewallet/ui/views/contacts/layouts/contact_detail.dart';
+import 'package:aewallet/ui/views/main/bloc/providers.dart';
 import 'package:aewallet/ui/widgets/components/sheet_util.dart';
 import 'package:aewallet/ui/widgets/components/show_sending_animation.dart';
 import 'package:aewallet/util/currency_util.dart';
@@ -89,10 +90,14 @@ class AccountListItem extends ConsumerWidget {
                   .refreshRecentTransactions();
             }
 
-            ref
+            await ref
                 .read(SettingsProviders.settings.notifier)
                 .resetMainScreenCurrentPage();
             Navigator.of(context).popUntil(RouteUtils.withNameLike('/home'));
+            ref.read(mainTabControllerProvider)!.animateTo(
+                  ref.read(SettingsProviders.settings).mainScreenCurrentPage,
+                  duration: Duration.zero,
+                );
           }
         },
         onLongPress: () {

--- a/lib/ui/views/main/bloc/providers.dart
+++ b/lib/ui/views/main/bloc/providers.dart
@@ -1,17 +1,32 @@
+import 'package:aewallet/domain/repositories/features_flags.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 final mainTabControllerProvider =
-    StateNotifierProvider<TabControllerNotifier, TabController?>((ref) {
+    StateNotifierProvider.autoDispose<TabControllerNotifier, TabController?>(
+        (ref) {
   return TabControllerNotifier();
 });
 
 class TabControllerNotifier extends StateNotifier<TabController?> {
-  TabControllerNotifier() : super(null);
+  TabControllerNotifier() : super(null) {
+    if (FeatureFlags.messagingActive) {
+      tabCount++;
+    }
+  }
 
-  TabController? get provider => state;
+  int tabCount = 4;
 
-  set provider(TabController? tabController) {
-    state = tabController;
+  void initState(TickerProvider tickerProvider) {
+    state = TabController(
+      length: tabCount,
+      vsync: tickerProvider,
+    );
+  }
+
+  @override
+  void dispose() {
+    state?.dispose();
+    super.dispose();
   }
 }

--- a/lib/ui/views/main/bloc/providers.dart
+++ b/lib/ui/views/main/bloc/providers.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final mainTabControllerProvider =
+    StateNotifierProvider<TabControllerNotifier, TabController?>((ref) {
+  return TabControllerNotifier();
+});
+
+class TabControllerNotifier extends StateNotifier<TabController?> {
+  TabControllerNotifier() : super(null);
+
+  TabController? get provider => state;
+
+  set provider(TabController? tabController) {
+    state = tabController;
+  }
+}

--- a/lib/ui/views/main/home_page.dart
+++ b/lib/ui/views/main/home_page.dart
@@ -50,10 +50,7 @@ class _HomePageState extends ConsumerState<HomePage>
     }
 
     WidgetsBinding.instance.addPostFrameCallback((_) async {
-      ref.read(mainTabControllerProvider.notifier).provider = TabController(
-        length: tabCount,
-        vsync: this,
-      );
+      ref.read(mainTabControllerProvider.notifier).initState(this);
 
       ref.read(mainTabControllerProvider)!.animateTo(
             ref.read(SettingsProviders.settings).mainScreenCurrentPage,

--- a/lib/ui/views/main/home_page.dart
+++ b/lib/ui/views/main/home_page.dart
@@ -12,6 +12,7 @@ import 'package:aewallet/ui/util/responsive.dart';
 import 'package:aewallet/ui/util/styles.dart';
 import 'package:aewallet/ui/views/main/account_tab.dart';
 import 'package:aewallet/ui/views/main/address_book_tab.dart';
+import 'package:aewallet/ui/views/main/bloc/providers.dart';
 import 'package:aewallet/ui/views/main/components/main_appbar.dart';
 import 'package:aewallet/ui/views/main/components/recovery_phrase_banner.dart';
 import 'package:aewallet/ui/views/main/keychain_tab.dart';
@@ -38,7 +39,6 @@ class HomePage extends ConsumerStatefulWidget {
 class _HomePageState extends ConsumerState<HomePage>
     with TickerProviderStateMixin {
   int tabCount = 4;
-  late TabController tabController;
 
   @override
   void initState() {
@@ -49,28 +49,28 @@ class _HomePageState extends ConsumerState<HomePage>
       tabCount++;
     }
 
-    tabController = TabController(
-      length: tabCount,
-      vsync: this,
-    );
-
     WidgetsBinding.instance.addPostFrameCallback((_) async {
-      tabController.animateTo(
-        ref.read(SettingsProviders.settings).mainScreenCurrentPage,
-        duration: Duration.zero,
+      ref.read(mainTabControllerProvider.notifier).provider = TabController(
+        length: tabCount,
+        vsync: this,
       );
-    });
-  }
 
-  @override
-  void dispose() {
-    tabController.dispose();
-    super.dispose();
+      ref.read(mainTabControllerProvider)!.animateTo(
+            ref.read(SettingsProviders.settings).mainScreenCurrentPage,
+            duration: Duration.zero,
+          );
+    });
   }
 
   @override
   Widget build(BuildContext context) {
     final theme = ref.watch(ThemeProviders.selectedTheme);
+
+    final tabController = ref.watch(mainTabControllerProvider);
+
+    if (tabController == null) {
+      return Container();
+    }
 
     return Scaffold(
       extendBodyBehindAppBar: true,


### PR DESCRIPTION
# Description

When we select another account, we should go into the home screen instead of staying in the account page

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Material used:

Please delete options that are not relevant.
- iOS (Smartphone/Tablet) : iPhone 14 Pro Max

## How Has This Been Tested?

Go into the account page, select another account => you go now to the home page

### Patrol

Please list here the tests created in Patrol for this pull request.

## Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

## Useful info for the reviewer:
