### PR TITLE
When the user logout, we will not have exceptions anymore

### DIFF
--- a/lib/application/contact.dart
+++ b/lib/application/contact.dart
@@ -31,10 +31,12 @@ Future<List<Contact>> _fetchContacts(
 }
 
 @riverpod
-Future<Contact> _getSelectedContact(_GetSelectedContactRef ref) async {
+Future<Contact?> _getSelectedContact(_GetSelectedContactRef ref) async {
   final selectedAccount =
       await ref.watch(AccountProviders.selectedAccount.future);
-  if (selectedAccount == null) throw Exception();
+  if (selectedAccount == null) {
+    return null;
+  }
 
   return ref.watch(
     _getContactWithNameProvider(
@@ -44,7 +46,7 @@ Future<Contact> _getSelectedContact(_GetSelectedContactRef ref) async {
 }
 
 @riverpod
-Future<Contact> _getContactWithName(
+Future<Contact?> _getContactWithName(
   _GetContactWithNameRef ref,
   String contactName,
 ) async {
@@ -213,7 +215,7 @@ class ContactRepository {
     return sl.get<DBHelper>().contactExistsWithName(contactName);
   }
 
-  Future<Contact> getContactWithName(String contactName) async {
+  Future<Contact?> getContactWithName(String contactName) async {
     return sl.get<DBHelper>().getContactWithName(contactName);
   }
 

--- a/lib/application/contact.g.dart
+++ b/lib/application/contact.g.dart
@@ -173,11 +173,12 @@ class _FetchContactsProviderElement
 }
 
 String _$getSelectedContactHash() =>
-    r'b76abfb987991770f9866447bd0d5b025705d7d9';
+    r'c58ac8b4086a82e2cad80f52ee48cbc3c6e2d415';
 
 /// See also [_getSelectedContact].
 @ProviderFor(_getSelectedContact)
-final _getSelectedContactProvider = AutoDisposeFutureProvider<Contact>.internal(
+final _getSelectedContactProvider =
+    AutoDisposeFutureProvider<Contact?>.internal(
   _getSelectedContact,
   name: r'_getSelectedContactProvider',
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
@@ -187,16 +188,16 @@ final _getSelectedContactProvider = AutoDisposeFutureProvider<Contact>.internal(
   allTransitiveDependencies: null,
 );
 
-typedef _GetSelectedContactRef = AutoDisposeFutureProviderRef<Contact>;
+typedef _GetSelectedContactRef = AutoDisposeFutureProviderRef<Contact?>;
 String _$getContactWithNameHash() =>
-    r'02013ceec0ce5f5617e7684f2a0f4bd80116843e';
+    r'e42c9606f79b6b6396b453ee26e7af18ae358470';
 
 /// See also [_getContactWithName].
 @ProviderFor(_getContactWithName)
 const _getContactWithNameProvider = _GetContactWithNameFamily();
 
 /// See also [_getContactWithName].
-class _GetContactWithNameFamily extends Family<AsyncValue<Contact>> {
+class _GetContactWithNameFamily extends Family<AsyncValue<Contact?>> {
   /// See also [_getContactWithName].
   const _GetContactWithNameFamily();
 
@@ -234,7 +235,7 @@ class _GetContactWithNameFamily extends Family<AsyncValue<Contact>> {
 }
 
 /// See also [_getContactWithName].
-class _GetContactWithNameProvider extends AutoDisposeFutureProvider<Contact> {
+class _GetContactWithNameProvider extends AutoDisposeFutureProvider<Contact?> {
   /// See also [_getContactWithName].
   _GetContactWithNameProvider(
     String contactName,
@@ -269,7 +270,7 @@ class _GetContactWithNameProvider extends AutoDisposeFutureProvider<Contact> {
 
   @override
   Override overrideWith(
-    FutureOr<Contact> Function(_GetContactWithNameRef provider) create,
+    FutureOr<Contact?> Function(_GetContactWithNameRef provider) create,
   ) {
     return ProviderOverride(
       origin: this,
@@ -286,7 +287,7 @@ class _GetContactWithNameProvider extends AutoDisposeFutureProvider<Contact> {
   }
 
   @override
-  AutoDisposeFutureProviderElement<Contact> createElement() {
+  AutoDisposeFutureProviderElement<Contact?> createElement() {
     return _GetContactWithNameProviderElement(this);
   }
 
@@ -305,13 +306,13 @@ class _GetContactWithNameProvider extends AutoDisposeFutureProvider<Contact> {
   }
 }
 
-mixin _GetContactWithNameRef on AutoDisposeFutureProviderRef<Contact> {
+mixin _GetContactWithNameRef on AutoDisposeFutureProviderRef<Contact?> {
   /// The parameter `contactName` of this provider.
   String get contactName;
 }
 
 class _GetContactWithNameProviderElement
-    extends AutoDisposeFutureProviderElement<Contact>
+    extends AutoDisposeFutureProviderElement<Contact?>
     with _GetContactWithNameRef {
   _GetContactWithNameProviderElement(super.provider);
 

--- a/lib/model/data/appdb.dart
+++ b/lib/model/data/appdb.dart
@@ -176,7 +176,7 @@ class DBHelper {
     }
   }
 
-  Future<Contact> getContactWithName(String contactName) async {
+  Future<Contact?> getContactWithName(String contactName) async {
     final box = await Hive.openBox<Contact>(contactsTable);
     final contactsList = box.values.toList();
     Contact? contactSelected;
@@ -190,11 +190,7 @@ class DBHelper {
         contactSelected = contact;
       }
     }
-    if (contactSelected == null) {
-      throw Exception();
-    } else {
-      return contactSelected;
-    }
+    return contactSelected;
   }
 
   Future<bool> contactExistsWithName(String contactName) async {

--- a/lib/ui/views/accounts/layouts/components/account_list_item.dart
+++ b/lib/ui/views/accounts/layouts/components/account_list_item.dart
@@ -37,7 +37,7 @@ class AccountListItem extends ConsumerWidget {
     final primaryCurrency =
         ref.watch(PrimaryCurrencyProviders.selectedPrimaryCurrency);
 
-    AsyncValue<Contact>? contact;
+    AsyncValue<Contact?>? contact;
     if (account.serviceType == 'archethicWallet') {
       contact = ref.watch(
         ContactProviders.getContactWithName(
@@ -108,7 +108,7 @@ class AccountListItem extends ConsumerWidget {
                   context: context,
                   ref: ref,
                   widget: ContactDetail(
-                    contact: data.value,
+                    contact: data.value!,
                   ),
                 );
               },

--- a/lib/ui/views/contacts/layouts/contact_detail.dart
+++ b/lib/ui/views/contacts/layouts/contact_detail.dart
@@ -273,7 +273,7 @@ class _ContactDetailActions extends ConsumerWidget {
                     return Icon(
                       Symbols.favorite,
                       color: theme.favoriteIconColor,
-                      fill: data.favorite == null || data.favorite == false
+                      fill: data!.favorite == null || data.favorite == false
                           ? 0
                           : 1,
                     );

--- a/lib/ui/views/messenger/bloc/create_discussion_form.dart
+++ b/lib/ui/views/messenger/bloc/create_discussion_form.dart
@@ -86,7 +86,8 @@ class CreateDiscussionFormNotifier
         if (selectedAccount == null) throw const Failure.loggedOut();
 
         final creator = AccessRecipient.contact(
-          contact: await ref.read(ContactProviders.getSelectedContact.future),
+          contact:
+              (await ref.read(ContactProviders.getSelectedContact.future))!,
         );
 
         await ref

--- a/lib/ui/views/messenger/bloc/providers.dart
+++ b/lib/ui/views/messenger/bloc/providers.dart
@@ -128,7 +128,7 @@ String _discussionDisplayName(
               final memberToDisplayPubKey =
                   discussion.membersPubKeys.firstWhereOrNull(
                 (memberPublicKey) =>
-                    memberPublicKey != contactData.value.publicKey,
+                    memberPublicKey != contactData.value!.publicKey,
               );
               if (memberToDisplayPubKey == null) return null;
 

--- a/lib/ui/views/messenger/bloc/providers.g.dart
+++ b/lib/ui/views/messenger/bloc/providers.g.dart
@@ -156,7 +156,7 @@ class _DiscussionProviderElement
 }
 
 String _$discussionDisplayNameHash() =>
-    r'ca1955ae1b91e4f54d33e98816e2f359534806b0';
+    r'5c65d094a29d76864a5e57d0f383da99df9ed664';
 
 /// See also [_discussionDisplayName].
 @ProviderFor(_discussionDisplayName)

--- a/lib/ui/views/nft_creation/bloc/provider.dart
+++ b/lib/ui/views/nft_creation/bloc/provider.dart
@@ -290,7 +290,7 @@ class NftCreationFormNotifier extends FamilyNotifier<NftCreationFormState,
       final contact = await sl.get<DBHelper>().getContactWithName(text);
       _setPropertyAccessRecipient(
         recipient: PropertyAccessRecipient.contact(
-          contact: contact,
+          contact: contact!,
         ),
       );
     } catch (e) {

--- a/lib/ui/views/transfer/bloc/provider.dart
+++ b/lib/ui/views/transfer/bloc/provider.dart
@@ -286,7 +286,7 @@ class TransferFormNotifier extends AutoDisposeNotifier<TransferFormState> {
       final contact = await sl.get<DBHelper>().getContactWithName(text);
       _setRecipient(
         recipient: TransferRecipient.contact(
-          contact: contact,
+          contact: contact!,
         ),
       );
     } catch (e) {


### PR DESCRIPTION
# Description

When the user logout, we will not have exceptions anymore

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Material used:

Please delete options that are not relevant.
- iOS (Smartphone/Tablet) : iPhone 14 Pro Max

## How Has This Been Tested?

Login with an user, then logout. Previously you had two exceptions threw, now zero.

### Patrol

Please list here the tests created in Patrol for this pull request.

## Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

## Useful info for the reviewer:
