### PR TITLE
Remove required authentification when user is not in auto lock period

### DIFF
--- a/lib/ui/views/nft_creation/layouts/components/nft_creation_confirm_sheet.dart
+++ b/lib/ui/views/nft_creation/layouts/components/nft_creation_confirm_sheet.dart
@@ -2,16 +2,13 @@
 import 'dart:async';
 
 import 'package:aewallet/application/account/providers.dart';
-import 'package:aewallet/application/settings/settings.dart';
 import 'package:aewallet/application/settings/theme.dart';
-import 'package:aewallet/bus/authenticated_event.dart';
 import 'package:aewallet/bus/transaction_send_event.dart';
 import 'package:aewallet/ui/themes/themes.dart';
 import 'package:aewallet/ui/util/dimens.dart';
 import 'package:aewallet/ui/util/routes.dart';
 import 'package:aewallet/ui/util/styles.dart';
 import 'package:aewallet/ui/util/ui_util.dart';
-import 'package:aewallet/ui/views/authenticate/auth_factory.dart';
 import 'package:aewallet/ui/views/nft_creation/bloc/provider.dart';
 import 'package:aewallet/ui/views/nft_creation/bloc/state.dart';
 import 'package:aewallet/ui/views/nft_creation/layouts/components/nft_creation_detail.dart';
@@ -37,29 +34,9 @@ class NftCreationConfirmSheet extends ConsumerStatefulWidget {
 class _NftCreationConfirmState extends ConsumerState<NftCreationConfirmSheet> {
   bool? animationOpen;
 
-  StreamSubscription<AuthenticatedEvent>? _authSub;
   StreamSubscription<TransactionSendEvent>? _sendTxSub;
 
   void _registerBus() {
-    _authSub = EventTaxiImpl.singleton()
-        .registerTo<AuthenticatedEvent>()
-        .listen((AuthenticatedEvent event) {
-      final theme = ref.read(ThemeProviders.selectedTheme);
-      ShowSendingAnimation.build(
-        context,
-        theme,
-      );
-      ref
-          .read(
-            NftCreationFormProvider.nftCreationForm(
-              ref.read(
-                NftCreationFormProvider.nftCreationFormArgs,
-              ),
-            ).notifier,
-          )
-          .send(context);
-    });
-
     _sendTxSub = EventTaxiImpl.singleton()
         .registerTo<TransactionSendEvent>()
         .listen((TransactionSendEvent event) async {
@@ -160,7 +137,6 @@ class _NftCreationConfirmState extends ConsumerState<NftCreationConfirmSheet> {
 
   @override
   void dispose() {
-    _authSub?.cancel();
     _sendTxSub?.cancel();
     super.dispose();
   }
@@ -241,17 +217,21 @@ class _NftCreationConfirmState extends ConsumerState<NftCreationConfirmSheet> {
                             key: const Key('confirm'),
                             icon: Symbols.check,
                             onPressed: () async {
-                              final auth = await AuthFactory.authenticate(
+                              ShowSendingAnimation.build(
                                 context,
-                                ref,
-                                activeVibrations: ref
-                                    .read(SettingsProviders.settings)
-                                    .activeVibrations,
+                                theme,
                               );
-                              if (auth) {
-                                EventTaxiImpl.singleton()
-                                    .fire(AuthenticatedEvent());
-                              }
+
+                              await ref
+                                  .read(
+                                    NftCreationFormProvider.nftCreationForm(
+                                      ref.read(
+                                        NftCreationFormProvider
+                                            .nftCreationFormArgs,
+                                      ),
+                                    ).notifier,
+                                  )
+                                  .send(context);
                             },
                             disabled:
                                 nftCreation.canConfirmNFTCreation == false,

--- a/lib/ui/views/rpc_command_receiver/add_service/layouts/add_service_confirmation_form.dart
+++ b/lib/ui/views/rpc_command_receiver/add_service/layouts/add_service_confirmation_form.dart
@@ -1,5 +1,4 @@
 import 'package:aewallet/application/account/providers.dart';
-import 'package:aewallet/application/settings/settings.dart';
 import 'package:aewallet/application/settings/theme.dart';
 import 'package:aewallet/domain/models/core/result.dart';
 import 'package:aewallet/domain/rpc/commands/command.dart';
@@ -11,7 +10,6 @@ import 'package:aewallet/ui/util/amount_formatters.dart';
 import 'package:aewallet/ui/util/dimens.dart';
 import 'package:aewallet/ui/util/styles.dart';
 import 'package:aewallet/ui/util/ui_util.dart';
-import 'package:aewallet/ui/views/authenticate/auth_factory.dart';
 import 'package:aewallet/ui/views/rpc_command_receiver/add_service/bloc/provider.dart';
 import 'package:aewallet/ui/views/rpc_command_receiver/rpc_failure_message.dart';
 import 'package:aewallet/ui/widgets/components/app_button_tiny.dart';
@@ -119,45 +117,36 @@ class AddServiceConfirmationForm extends ConsumerWidget {
                       localizations.confirm,
                       Dimens.buttonBottomDimens,
                       onPressed: () async {
-                        final auth = await AuthFactory.authenticate(
+                        ShowSendingAnimation.build(
                           context,
-                          ref,
-                          activeVibrations: ref
-                              .read(SettingsProviders.settings)
-                              .activeVibrations,
+                          theme,
                         );
-                        if (auth) {
-                          ShowSendingAnimation.build(
-                            context,
-                            theme,
-                          );
 
-                          final result = await formNotifier.send(
-                            (progress) {
-                              _showSendProgress(
-                                context,
-                                ref,
-                                theme,
-                                progress,
-                              );
-                            },
-                          );
+                        final result = await formNotifier.send(
+                          (progress) {
+                            _showSendProgress(
+                              context,
+                              ref,
+                              theme,
+                              progress,
+                            );
+                          },
+                        );
 
-                          result.map(
-                            success: (success) {},
-                            failure: (failure) {
-                              _showSendFailed(
-                                context,
-                                ref,
-                                theme,
-                                failure,
-                              );
-                            },
-                          );
+                        result.map(
+                          success: (success) {},
+                          failure: (failure) {
+                            _showSendFailed(
+                              context,
+                              ref,
+                              theme,
+                              failure,
+                            );
+                          },
+                        );
 
-                          Navigator.of(context).pop(); // Hide SendingAnimation
-                          Navigator.of(context).pop(result);
-                        }
+                        Navigator.of(context).pop(); // Hide SendingAnimation
+                        Navigator.of(context).pop(result);
                       },
                     ),
                   ],

--- a/lib/ui/views/rpc_command_receiver/send_transaction/layouts/send_transaction_confirmation_form.dart
+++ b/lib/ui/views/rpc_command_receiver/send_transaction/layouts/send_transaction_confirmation_form.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
 
 import 'package:aewallet/application/account/providers.dart';
-import 'package:aewallet/application/settings/settings.dart';
 import 'package:aewallet/application/settings/theme.dart';
 import 'package:aewallet/domain/models/core/result.dart';
 import 'package:aewallet/domain/rpc/commands/command.dart';
@@ -13,7 +12,6 @@ import 'package:aewallet/ui/util/amount_formatters.dart';
 import 'package:aewallet/ui/util/dimens.dart';
 import 'package:aewallet/ui/util/styles.dart';
 import 'package:aewallet/ui/util/ui_util.dart';
-import 'package:aewallet/ui/views/authenticate/auth_factory.dart';
 import 'package:aewallet/ui/views/rpc_command_receiver/rpc_failure_message.dart';
 import 'package:aewallet/ui/views/rpc_command_receiver/send_transaction/bloc/provider.dart';
 import 'package:aewallet/ui/widgets/components/app_button_tiny.dart';
@@ -171,45 +169,36 @@ class SendTransactionConfirmationForm extends ConsumerWidget {
                       localizations.confirm,
                       Dimens.buttonBottomDimens,
                       onPressed: () async {
-                        final auth = await AuthFactory.authenticate(
+                        ShowSendingAnimation.build(
                           context,
-                          ref,
-                          activeVibrations: ref
-                              .read(SettingsProviders.settings)
-                              .activeVibrations,
+                          theme,
                         );
-                        if (auth) {
-                          ShowSendingAnimation.build(
-                            context,
-                            theme,
-                          );
 
-                          final result = await formNotifier.send(
-                            (progress) {
-                              _showSendProgress(
-                                context,
-                                ref,
-                                theme,
-                                progress,
-                              );
-                            },
-                          );
+                        final result = await formNotifier.send(
+                          (progress) {
+                            _showSendProgress(
+                              context,
+                              ref,
+                              theme,
+                              progress,
+                            );
+                          },
+                        );
 
-                          result.map(
-                            success: (success) {},
-                            failure: (failure) {
-                              _showSendFailed(
-                                context,
-                                ref,
-                                theme,
-                                failure,
-                              );
-                            },
-                          );
+                        result.map(
+                          success: (success) {},
+                          failure: (failure) {
+                            _showSendFailed(
+                              context,
+                              ref,
+                              theme,
+                              failure,
+                            );
+                          },
+                        );
 
-                          Navigator.of(context).pop(); // Hide SendingAnimation
-                          Navigator.of(context).pop(result);
-                        }
+                        Navigator.of(context).pop(); // Hide SendingAnimation
+                        Navigator.of(context).pop(result);
                       },
                     ),
                   ],

--- a/lib/ui/views/rpc_command_receiver/sign_transactions/layouts/sign_transactions_confirmation_form.dart
+++ b/lib/ui/views/rpc_command_receiver/sign_transactions/layouts/sign_transactions_confirmation_form.dart
@@ -1,10 +1,8 @@
-import 'package:aewallet/application/settings/settings.dart';
 import 'package:aewallet/application/settings/theme.dart';
 import 'package:aewallet/domain/rpc/commands/command.dart';
 import 'package:aewallet/domain/rpc/commands/sign_transactions.dart';
 import 'package:aewallet/ui/util/dimens.dart';
 import 'package:aewallet/ui/util/styles.dart';
-import 'package:aewallet/ui/views/authenticate/auth_factory.dart';
 import 'package:aewallet/ui/views/rpc_command_receiver/sign_transactions/bloc/provider.dart';
 import 'package:aewallet/ui/views/rpc_command_receiver/sign_transactions/layouts/transaction_raw.dart';
 import 'package:aewallet/ui/widgets/components/app_button_tiny.dart';
@@ -129,16 +127,7 @@ class SignTransactionsConfirmationForm extends ConsumerWidget {
                       localizations.confirm,
                       Dimens.buttonBottomDimens,
                       onPressed: () async {
-                        final auth = await AuthFactory.authenticate(
-                          context,
-                          ref,
-                          activeVibrations: ref
-                              .read(SettingsProviders.settings)
-                              .activeVibrations,
-                        );
-                        if (auth) {
-                          Navigator.of(context).pop(auth);
-                        }
+                        Navigator.of(context).pop(true);
                       },
                     ),
                   ],

--- a/lib/ui/views/tokens_fungibles/layouts/components/add_token_confirm_sheet.dart
+++ b/lib/ui/views/tokens_fungibles/layouts/components/add_token_confirm_sheet.dart
@@ -2,16 +2,13 @@
 import 'dart:async';
 
 import 'package:aewallet/application/account/providers.dart';
-import 'package:aewallet/application/settings/settings.dart';
 import 'package:aewallet/application/settings/theme.dart';
-import 'package:aewallet/bus/authenticated_event.dart';
 import 'package:aewallet/bus/transaction_send_event.dart';
 import 'package:aewallet/ui/themes/themes.dart';
 import 'package:aewallet/ui/util/dimens.dart';
 import 'package:aewallet/ui/util/routes.dart';
 import 'package:aewallet/ui/util/styles.dart';
 import 'package:aewallet/ui/util/ui_util.dart';
-import 'package:aewallet/ui/views/authenticate/auth_factory.dart';
 import 'package:aewallet/ui/views/tokens_fungibles/bloc/provider.dart';
 import 'package:aewallet/ui/views/tokens_fungibles/bloc/state.dart';
 import 'package:aewallet/ui/views/tokens_fungibles/layouts/components/add_token_detail.dart';
@@ -36,22 +33,9 @@ class AddTokenConfirmSheet extends ConsumerStatefulWidget {
 class _AddTokenConfirmState extends ConsumerState<AddTokenConfirmSheet> {
   bool? animationOpen;
 
-  StreamSubscription<AuthenticatedEvent>? _authSub;
   StreamSubscription<TransactionSendEvent>? _sendTxSub;
 
   void _registerBus() {
-    _authSub = EventTaxiImpl.singleton()
-        .registerTo<AuthenticatedEvent>()
-        .listen((AuthenticatedEvent event) {
-      final theme = ref.read(ThemeProviders.selectedTheme);
-      ShowSendingAnimation.build(
-        context,
-        theme,
-      );
-
-      ref.read(AddTokenFormProvider.addTokenForm.notifier).send(context);
-    });
-
     _sendTxSub = EventTaxiImpl.singleton()
         .registerTo<TransactionSendEvent>()
         .listen((TransactionSendEvent event) async {
@@ -139,7 +123,6 @@ class _AddTokenConfirmState extends ConsumerState<AddTokenConfirmSheet> {
 
   @override
   void dispose() {
-    _authSub?.cancel();
     _sendTxSub?.cancel();
     super.dispose();
   }
@@ -189,16 +172,13 @@ class _AddTokenConfirmState extends ConsumerState<AddTokenConfirmSheet> {
                       key: const Key('confirm'),
                       icon: Symbols.check,
                       onPressed: () async {
-                        final auth = await AuthFactory.authenticate(
+                        ShowSendingAnimation.build(
                           context,
-                          ref,
-                          activeVibrations: ref
-                              .read(SettingsProviders.settings)
-                              .activeVibrations,
+                          theme,
                         );
-                        if (auth) {
-                          EventTaxiImpl.singleton().fire(AuthenticatedEvent());
-                        }
+                        await ref
+                            .read(AddTokenFormProvider.addTokenForm.notifier)
+                            .send(context);
                       },
                     ),
                   ],

--- a/lib/ui/views/transfer/layouts/components/transfer_confirm_sheet.dart
+++ b/lib/ui/views/transfer/layouts/components/transfer_confirm_sheet.dart
@@ -3,15 +3,12 @@ import 'dart:async';
 
 // Project imports:
 import 'package:aewallet/application/account/providers.dart';
-import 'package:aewallet/application/settings/settings.dart';
 import 'package:aewallet/application/settings/theme.dart';
-import 'package:aewallet/bus/authenticated_event.dart';
 import 'package:aewallet/bus/transaction_send_event.dart';
 import 'package:aewallet/ui/themes/themes.dart';
 import 'package:aewallet/ui/util/dimens.dart';
 import 'package:aewallet/ui/util/routes.dart';
 import 'package:aewallet/ui/util/ui_util.dart';
-import 'package:aewallet/ui/views/authenticate/auth_factory.dart';
 import 'package:aewallet/ui/views/transfer/bloc/provider.dart';
 import 'package:aewallet/ui/views/transfer/bloc/state.dart';
 import 'package:aewallet/ui/views/transfer/layouts/components/token_transfer_detail.dart';
@@ -45,22 +42,9 @@ class TransferConfirmSheet extends ConsumerStatefulWidget {
 class _TransferConfirmSheetState extends ConsumerState<TransferConfirmSheet> {
   bool? animationOpen;
 
-  StreamSubscription<AuthenticatedEvent>? _authSub;
   StreamSubscription<TransactionSendEvent>? _sendTxSub;
 
   void _registerBus() {
-    _authSub = EventTaxiImpl.singleton()
-        .registerTo<AuthenticatedEvent>()
-        .listen((AuthenticatedEvent event) {
-      final theme = ref.read(ThemeProviders.selectedTheme);
-      ShowSendingAnimation.build(
-        context,
-        theme,
-      );
-
-      ref.read(TransferFormProvider.transferForm.notifier).send(context);
-    });
-
     _sendTxSub = EventTaxiImpl.singleton()
         .registerTo<TransactionSendEvent>()
         .listen((TransactionSendEvent event) async {
@@ -175,7 +159,6 @@ class _TransferConfirmSheetState extends ConsumerState<TransferConfirmSheet> {
 
   @override
   void dispose() {
-    _authSub?.cancel();
     _sendTxSub?.cancel();
     super.dispose();
   }
@@ -229,16 +212,13 @@ class _TransferConfirmSheetState extends ConsumerState<TransferConfirmSheet> {
                       key: const Key('confirm'),
                       icon: Symbols.check,
                       onPressed: () async {
-                        final auth = await AuthFactory.authenticate(
+                        ShowSendingAnimation.build(
                           context,
-                          ref,
-                          activeVibrations: ref
-                              .read(SettingsProviders.settings)
-                              .activeVibrations,
+                          theme,
                         );
-                        if (auth) {
-                          EventTaxiImpl.singleton().fire(AuthenticatedEvent());
-                        }
+                        await ref
+                            .read(TransferFormProvider.transferForm.notifier)
+                            .send(context);
                       },
                     ),
                   ],


### PR DESCRIPTION
# Description

In exchanges with Dapps and the wallet, users must authenticate themselves each time they sign a transaction or send one. 
This is not necessary, as the user's session is managed by the "Auto lock" parameter.
The same applies to confirmations for sending UCOs, creating tokens, creating service/account or NFTs.

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

## Material used:

Please delete options that are not relevant.
- iOS (Mac)

## Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

## Useful info for the reviewer:
