### PR TITLE
✨ Remove account from keychain

### DIFF
--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -398,6 +398,8 @@
   "addAccountConfirmed": "The account was created with %1 confirmations on %2",
   "transferConfirmed1": "The transfer was made with %1 confirmation on %2",
   "transferConfirmed": "The transfer was made with %1 confirmations on %2",
+  "retireAccountConfirmed1": "The account was retired with %1 confirmation on %2",
+  "retireAccountConfirmed": "The account was retired with %1 confirmations on %2",
   "build": "Build :",
   "nftCategoryArt": "Art",
   "nftCategoryAccess": "Access",
@@ -608,5 +610,9 @@
   "youHaveBeenDeletedFromADiscussion": "You have been deleted from a discussion",
   "youHaveBeenAddedTOADiscussion": "You have been added to a discussion",
   "localDataMigrationMessage": "Update your current application.\nPlease wait...",
-  "nftNotOwnerInfo": "You are not the owner of this NFT"
+  "nftNotOwnerInfo": "You are not the owner of this NFT",
+  "removeKeychainDetail": "You are about to retire the account %1 from your keychain.\nYou will no longer have access to the funds or associated tokens.\nRefer to your keychain history to access information related to this account.",
+  "removeKeychainAction": "Remove",
+  "removeKeychainLater": "You will be able to find your account if you recreate it later with the same name.",
+  "removeKeychainAtLeast1": "You must keep at least one account in your keychain."
 }

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -390,6 +390,8 @@
 	"addAccountConfirmed": "Le compte a été créé avec %1 confirmations sur %2",
 	"transferConfirmed1": "Le transfert a été effectué avec %1 confirmation sur %2",
 	"transferConfirmed": "Le transfert a été effectué avec %1 confirmations sur %2",
+	"retireAccountConfirmed1": "Le compte a été retiré du porte-clés avec %1 confirmation sur %2",
+	"retireAccountConfirmed": "Le compte a été retiré du porte-clés avec %1 confirmations sur %2",
 	"build": "Build : ",
 	"nftCategoryArt": "Art",
 	"nftCategoryAccess": "Accès",
@@ -585,5 +587,9 @@
 	"youHaveBeenDeletedFromADiscussion": "Vous avez été supprimé d'une discussion",
 	"youHaveBeenAddedTOADiscussion": "Vous avez été ajouté à une discussion",
 	"localDataMigrationMessage": "Mise à jour de votre application en cours.\nVeuillez patienter...",
-	"nftNotOwnerInfo": "Vous n'êtes pas propriétaire de ce NFT"
+	"nftNotOwnerInfo": "Vous n'êtes pas propriétaire de ce NFT",
+	"removeKeychainDetail": "Vous vous apprêtez à retirer de votre porte-clés le compte %1.\nVous n'aurez plus accès ni aux fonds, ni aux tokens associés.\nRéférez vous à l'historique de votre porte-clés afin de pouvoir accéder aux informations relatives à ce compte.",
+	"removeKeychainAction": "Retirer le compte",
+	"removeKeychainLater": "Vous pourrez retrouver votre compte si vous le récréez plus tard avec le même nom.",
+	"removeKeychainAtLeast1": "Vous devez conserver au moins un service dans votre porte-clés."
 }

--- a/lib/ui/views/accounts/layouts/components/account_list_item.dart
+++ b/lib/ui/views/accounts/layouts/components/account_list_item.dart
@@ -1,30 +1,45 @@
 /// SPDX-License-Identifier: AGPL-3.0-or-later
+import 'dart:async';
+
 import 'package:aewallet/application/account/providers.dart';
 import 'package:aewallet/application/contact.dart';
 import 'package:aewallet/application/market_price.dart';
+import 'package:aewallet/application/settings/language.dart';
 import 'package:aewallet/application/settings/primary_currency.dart';
 import 'package:aewallet/application/settings/settings.dart';
 import 'package:aewallet/application/settings/theme.dart';
+import 'package:aewallet/application/wallet/wallet.dart';
+import 'package:aewallet/bus/transaction_send_event.dart';
+import 'package:aewallet/model/available_language.dart';
 import 'package:aewallet/model/data/account.dart';
 import 'package:aewallet/model/data/contact.dart';
 import 'package:aewallet/model/primary_currency.dart';
+import 'package:aewallet/ui/themes/themes.dart';
 import 'package:aewallet/ui/util/routes.dart';
 import 'package:aewallet/ui/util/service_type_formatters.dart';
 import 'package:aewallet/ui/util/styles.dart';
+import 'package:aewallet/ui/util/ui_util.dart';
 import 'package:aewallet/ui/views/accounts/layouts/components/account_list_item_token_info.dart';
 import 'package:aewallet/ui/views/contacts/layouts/contact_detail.dart';
 import 'package:aewallet/ui/views/main/bloc/providers.dart';
+import 'package:aewallet/ui/widgets/components/dialog.dart';
 import 'package:aewallet/ui/widgets/components/sheet_util.dart';
 import 'package:aewallet/ui/widgets/components/show_sending_animation.dart';
+import 'package:aewallet/util/case_converter.dart';
 import 'package:aewallet/util/currency_util.dart';
 import 'package:aewallet/util/get_it_instance.dart';
 import 'package:aewallet/util/haptic_util.dart';
+import 'package:aewallet/util/keychain_util.dart';
+import 'package:archethic_lib_dart/archethic_lib_dart.dart';
 import 'package:auto_size_text/auto_size_text.dart';
+import 'package:event_taxi/event_taxi.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_vibrate/flutter_vibrate.dart';
+import 'package:material_symbols_icons/symbols.dart';
 
-class AccountListItem extends ConsumerWidget {
+class AccountListItem extends ConsumerStatefulWidget {
   const AccountListItem({
     super.key,
     required this.account,
@@ -32,17 +47,116 @@ class AccountListItem extends ConsumerWidget {
   final Account account;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<AccountListItem> createState() => _AccountListItemState();
+}
+
+class _AccountListItemState extends ConsumerState<AccountListItem> {
+  StreamSubscription<TransactionSendEvent>? _sendTxSub;
+
+  void _registerBus() {
+    _sendTxSub = EventTaxiImpl.singleton()
+        .registerTo<TransactionSendEvent>()
+        .listen((TransactionSendEvent event) async {
+      final theme = ref.watch(ThemeProviders.selectedTheme);
+      if (event.response != 'ok' && event.nbConfirmations == 0) {
+        // Send failed
+        _showSendFailed(event, theme);
+        return;
+      }
+
+      if (event.response == 'ok') {
+        await _showSendSucceed(event, theme);
+        return;
+      }
+
+      _showNotEnoughConfirmation(theme);
+    });
+  }
+
+  void _showNotEnoughConfirmation(BaseTheme theme) {
+    UIUtil.showSnackbar(
+      AppLocalizations.of(context)!.notEnoughConfirmations,
+      context,
+      ref,
+      theme.text!,
+      theme.snackBarShadow!,
+      icon: Symbols.info,
+    );
+    Navigator.of(context).pop();
+  }
+
+  Future<void> _showSendSucceed(
+    TransactionSendEvent event,
+    BaseTheme theme,
+  ) async {
+    UIUtil.showSnackbar(
+      event.nbConfirmations == 1
+          ? AppLocalizations.of(context)!
+              .retireAccountConfirmed1
+              .replaceAll('%1', event.nbConfirmations.toString())
+              .replaceAll('%2', event.maxConfirmations.toString())
+          : AppLocalizations.of(context)!
+              .retireAccountConfirmed
+              .replaceAll('%1', event.nbConfirmations.toString())
+              .replaceAll('%2', event.maxConfirmations.toString()),
+      context,
+      ref,
+      theme.text!,
+      theme.snackBarShadow!,
+      duration: const Duration(milliseconds: 5000),
+      icon: Symbols.info,
+    );
+    await ref.read(SessionProviders.session.notifier).refresh();
+    await ref
+        .read(AccountProviders.selectedAccount.notifier)
+        .refreshRecentTransactions();
+
+    if (mounted) {
+      Navigator.of(context).popUntil(RouteUtils.withNameLike('/home'));
+    }
+  }
+
+  void _showSendFailed(
+    TransactionSendEvent event,
+    BaseTheme theme,
+  ) {
+    UIUtil.showSnackbar(
+      event.response!,
+      context,
+      ref,
+      theme.text!,
+      theme.snackBarShadow!,
+      duration: const Duration(seconds: 5),
+    );
+    Navigator.of(context).pop();
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _registerBus();
+  }
+
+  @override
+  void dispose() {
+    _sendTxSub?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final preferences = ref.watch(SettingsProviders.settings);
+    final localizations = AppLocalizations.of(context)!;
     final theme = ref.watch(ThemeProviders.selectedTheme);
     final settings = ref.watch(SettingsProviders.settings);
     final primaryCurrency =
         ref.watch(PrimaryCurrencyProviders.selectedPrimaryCurrency);
 
     AsyncValue<Contact?>? contact;
-    if (account.serviceType == 'archethicWallet') {
+    if (widget.account.serviceType == 'archethicWallet') {
       contact = ref.watch(
         ContactProviders.getContactWithName(
-          Uri.encodeFull(account.nameDisplayed),
+          Uri.encodeFull(widget.account.nameDisplayed),
         ),
       );
     }
@@ -52,7 +166,7 @@ class AccountListItem extends ConsumerWidget {
 
     final asyncFiatAmount = ref.watch(
       MarketPriceProviders.convertedToSelectedCurrency(
-        nativeAmount: account.balance?.nativeTokenValue ?? 0,
+        nativeAmount: widget.account.balance?.nativeTokenValue ?? 0,
       ),
     );
     final fiatAmountString = asyncFiatAmount.maybeWhen(
@@ -67,7 +181,7 @@ class AccountListItem extends ConsumerWidget {
       padding: const EdgeInsets.only(bottom: 8),
       child: GestureDetector(
         onTap: () async {
-          if (account.serviceType == 'archethicWallet') {
+          if (widget.account.serviceType == 'archethicWallet') {
             sl.get<HapticUtil>().feedback(
                   FeedbackType.light,
                   ref.read(
@@ -78,14 +192,14 @@ class AccountListItem extends ConsumerWidget {
                 );
 
             if (selectedAccount == null ||
-                selectedAccount.nameDisplayed != account.nameDisplayed) {
+                selectedAccount.nameDisplayed != widget.account.nameDisplayed) {
               ShowSendingAnimation.build(context, theme);
               await ref
                   .read(AccountProviders.accounts.notifier)
-                  .selectAccount(account);
+                  .selectAccount(widget.account);
               await ref
                   .read(
-                    AccountProviders.account(account.name).notifier,
+                    AccountProviders.account(widget.account.name).notifier,
                   )
                   .refreshRecentTransactions();
             }
@@ -101,7 +215,7 @@ class AccountListItem extends ConsumerWidget {
           }
         },
         onLongPress: () {
-          if (account.serviceType != 'other') {
+          if (widget.account.serviceType != 'other') {
             return contact!.map(
               data: (data) {
                 sl.get<HapticUtil>().feedback(
@@ -131,12 +245,12 @@ class AccountListItem extends ConsumerWidget {
             borderRadius: BorderRadius.circular(10),
           ),
           elevation: 0,
-          color: account.serviceType == 'archethicWallet'
+          color: widget.account.serviceType == 'archethicWallet'
               ? theme.backgroundAccountsListCardSelected
               : Colors.transparent,
           child: Container(
-            height: account.serviceType != 'aeweb' ? 90 : 60,
-            color: account.selected!
+            height: widget.account.serviceType != 'aeweb' ? 100 : 70,
+            color: widget.account.selected!
                 ? theme.backgroundAccountsListCardSelected
                 : theme.backgroundAccountsListCard,
             padding: const EdgeInsets.symmetric(
@@ -150,53 +264,190 @@ class AccountListItem extends ConsumerWidget {
                 Expanded(
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisAlignment: MainAxisAlignment.center,
                     children: [
-                      AutoSizeText(
-                        account.nameDisplayed,
-                        style: theme.textStyleSize12W400Primary,
+                      SizedBox(
+                        height: 17,
+                        child: AutoSizeText(
+                          widget.account.nameDisplayed,
+                          style: theme.textStyleSize12W400Primary,
+                        ),
                       ),
-                      const SizedBox(height: 2),
-                      if (account.serviceType != null)
+                      if (widget.account.serviceType != null)
                         Row(
                           children: [
                             Icon(
-                              ServiceTypeFormatters(account.serviceType!)
+                              ServiceTypeFormatters(widget.account.serviceType!)
                                   .getIcon(),
                               size: 15,
                             ),
                             const SizedBox(width: 3),
                             AutoSizeText(
-                              ServiceTypeFormatters(account.serviceType!)
+                              ServiceTypeFormatters(widget.account.serviceType!)
                                   .getLabel(context),
                               style: theme.textStyleSize12W400Primary,
                             ),
                           ],
                         ),
+                      const SizedBox(
+                        height: 5,
+                      ),
+                      Row(
+                        children: [
+                          Container(
+                            alignment: Alignment.center,
+                            height: 30,
+                            width: 30,
+                            decoration: BoxDecoration(
+                              borderRadius: BorderRadius.circular(10),
+                              color: theme.backgroundDark!.withOpacity(0.3),
+                              border: Border.all(
+                                color:
+                                    theme.backgroundDarkest!.withOpacity(0.2),
+                              ),
+                            ),
+                            child: InkWell(
+                              child: Icon(
+                                Symbols.open_in_new,
+                                color: theme.backgroundDarkest,
+                                size: 16,
+                              ),
+                              onTap: () async {
+                                sl.get<HapticUtil>().feedback(
+                                      FeedbackType.light,
+                                      preferences.activeVibrations,
+                                    );
+                                UIUtil.showWebview(
+                                  context,
+                                  '${ref.read(SettingsProviders.settings).network.getLink()}/explorer/transaction/${widget.account.lastAddress}',
+                                  '',
+                                );
+                              },
+                            ),
+                          ),
+                          const SizedBox(
+                            width: 10,
+                          ),
+                          Container(
+                            alignment: Alignment.center,
+                            height: 30,
+                            width: 30,
+                            decoration: BoxDecoration(
+                              borderRadius: BorderRadius.circular(10),
+                              color: theme.backgroundDark!.withOpacity(0.3),
+                              border: Border.all(
+                                color:
+                                    theme.backgroundDarkest!.withOpacity(0.2),
+                              ),
+                            ),
+                            child: InkWell(
+                              child: Icon(
+                                Symbols.delete,
+                                color: theme.backgroundDarkest,
+                                size: 16,
+                              ),
+                              onTap: () async {
+                                final session =
+                                    ref.read(SessionProviders.session).loggedIn;
+                                final keychain = await sl
+                                    .get<ApiService>()
+                                    .getKeychain(session!.wallet.seed);
+
+                                if (keychain.services.length == 1) {
+                                  UIUtil.showSnackbar(
+                                    AppLocalizations.of(context)!
+                                        .removeKeychainAtLeast1,
+                                    context,
+                                    ref,
+                                    theme.text!,
+                                    theme.snackBarShadow!,
+                                    icon: Symbols.info,
+                                  );
+                                  return;
+                                }
+
+                                final language = ref.read(
+                                  LanguageProviders.selectedLanguage,
+                                );
+
+                                sl.get<HapticUtil>().feedback(
+                                      FeedbackType.light,
+                                      preferences.activeVibrations,
+                                    );
+                                AppDialogs.showConfirmDialog(
+                                    context,
+                                    ref,
+                                    CaseChange.toUpperCase(
+                                      localizations.warning,
+                                      language.getLocaleString(),
+                                    ),
+                                    localizations.removeKeychainDetail
+                                        .replaceAll(
+                                      '%1',
+                                      widget.account.nameDisplayed,
+                                    ),
+                                    localizations.removeKeychainAction, () {
+                                  // Show another confirm dialog
+                                  AppDialogs.showConfirmDialog(
+                                    context,
+                                    ref,
+                                    localizations.areYouSure,
+                                    localizations.removeKeychainLater,
+                                    localizations.yes,
+                                    () async {
+                                      ShowSendingAnimation.build(
+                                        context,
+                                        theme,
+                                      );
+
+                                      await KeychainUtil().removeService(
+                                        ref
+                                            .read(SettingsProviders.settings)
+                                            .network,
+                                        widget.account.name,
+                                        keychain,
+                                      );
+                                    },
+                                  );
+                                });
+                              },
+                            ),
+                          ),
+                        ],
+                      ),
                     ],
                   ),
                 ),
-                if (account.serviceType != 'aeweb')
+                if (widget.account.serviceType != 'aeweb')
                   if (settings.showBalances)
                     primaryCurrency.primaryCurrency ==
                             AvailablePrimaryCurrencyEnum.native
                         ? Column(
                             crossAxisAlignment: CrossAxisAlignment.end,
+                            mainAxisAlignment: MainAxisAlignment.center,
                             children: <Widget>[
-                              AutoSizeText(
-                                '${account.balance!.nativeTokenValueToString(digits: 2)} ${account.balance!.nativeTokenName}',
-                                style: theme.textStyleSize12W400Primary,
-                                textAlign: TextAlign.end,
+                              SizedBox(
+                                height: 17,
+                                child: AutoSizeText(
+                                  '${widget.account.balance!.nativeTokenValueToString(digits: 2)} ${widget.account.balance!.nativeTokenName}',
+                                  style: theme.textStyleSize12W400Primary,
+                                  textAlign: TextAlign.end,
+                                ),
                               ),
-                              AutoSizeText(
-                                fiatAmountString,
-                                textAlign: TextAlign.end,
-                                style: theme.textStyleSize12W400Primary,
+                              SizedBox(
+                                height: 17,
+                                child: AutoSizeText(
+                                  fiatAmountString,
+                                  textAlign: TextAlign.end,
+                                  style: theme.textStyleSize12W400Primary,
+                                ),
                               ),
-                              AccountListItemTokenInfo(account: account),
+                              AccountListItemTokenInfo(account: widget.account),
                             ],
                           )
                         : Column(
                             crossAxisAlignment: CrossAxisAlignment.end,
+                            mainAxisAlignment: MainAxisAlignment.center,
                             children: <Widget>[
                               AutoSizeText(
                                 fiatAmountString,
@@ -204,11 +455,11 @@ class AccountListItem extends ConsumerWidget {
                                 style: theme.textStyleSize12W400Primary,
                               ),
                               AutoSizeText(
-                                '${account.balance!.nativeTokenValueToString(digits: 2)} ${account.balance!.nativeTokenName}',
+                                '${widget.account.balance!.nativeTokenValueToString(digits: 2)} ${widget.account.balance!.nativeTokenName}',
                                 style: theme.textStyleSize12W400Primary,
                                 textAlign: TextAlign.end,
                               ),
-                              AccountListItemTokenInfo(account: account),
+                              AccountListItemTokenInfo(account: widget.account),
                             ],
                           )
                   else
@@ -224,12 +475,12 @@ class AccountListItem extends ConsumerWidget {
                           '···········',
                           style: theme.textStyleSize12W600Primary60,
                         ),
-                        if (account.serviceType != 'aeweb')
+                        if (widget.account.serviceType != 'aeweb')
                           AutoSizeText(
                             '···········',
                             style: theme.textStyleSize12W600Primary60,
                           ),
-                        if (account.serviceType != 'aeweb')
+                        if (widget.account.serviceType != 'aeweb')
                           AutoSizeText(
                             '···········',
                             style: theme.textStyleSize12W600Primary60,


### PR DESCRIPTION
# Description

This PR allows user to retire from a keychain an account/service.

Fixes #525

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

## Material used:

Please delete options that are not relevant.
- iOS (Mac)

## How Has This Been Tested?

In the keychain tab, user click on retire icon. After a double confirmations, the account/service is retired from the keychain.
It's not possible to retire all account. We need keep at least 1 account/service.
If user wants to find his retire account, he can recreate it with the same name.
All are in the blockchain !

## Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

## Useful info for the reviewer:
