### PR TITLE
✨ Display the seed in hex

### DIFF
--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -609,5 +609,6 @@
   "removeKeychainLater": "You will be able to find your account if you recreate it later with the same name.",
   "removeKeychainAtLeast1": "You must keep at least one account in your keychain.",
   "balance": "Balance",
-  "executionSC": "Smart-contract execution"
+  "executionSC": "Smart-contract execution",
+  "seedHex": "Hexadecimal Phrase"
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -610,5 +610,5 @@
   "removeKeychainAtLeast1": "You must keep at least one account in your keychain.",
   "balance": "Balance",
   "executionSC": "Smart-contract execution",
-  "seedHex": "Hexadecimal Phrase"
+  "seedHex": "View in Hexadecimal"
 }

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -586,5 +586,6 @@
 	"removeKeychainLater": "Vous pourrez retrouver votre compte si vous le récréez plus tard avec le même nom.",
 	"removeKeychainAtLeast1": "Vous devez conserver au moins un service dans votre porte-clés.",
 	"balance": "Balance",
-	"executionSC": "Execution Smart-contract"
+	"executionSC": "Execution Smart-contract",
+	"seedHex": "Phrase en hexadécimal"
 }

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -587,5 +587,5 @@
 	"removeKeychainAtLeast1": "Vous devez conserver au moins un service dans votre porte-clés.",
 	"balance": "Balance",
 	"executionSC": "Execution Smart-contract",
-	"seedHex": "Phrase en hexadécimal"
+	"seedHex": "Voir en hexadécimal"
 }

--- a/lib/ui/menu/settings/security_menu_view.dart
+++ b/lib/ui/menu/settings/security_menu_view.dart
@@ -298,7 +298,7 @@ class _BackupSecretPhraseListItem extends ConsumerWidget {
           Sheets.showAppHeightNineSheet(
             context: context,
             ref: ref,
-            widget: AppSeedBackupSheet(mnemonic),
+            widget: AppSeedBackupSheet(mnemonic, seed),
           );
         }
       },

--- a/lib/ui/themes/archethic_theme.dart
+++ b/lib/ui/themes/archethic_theme.dart
@@ -98,7 +98,7 @@ class ArchethicTheme {
   static Color animationOverlayStrong =
       const Color(0xFF000000).withOpacity(0.85);
   static Color overlay30 = const Color(0xFF000000).withOpacity(0.3);
-  static Color numMnemonicBackground = Colors.grey.shade800;
+  static Color seedInfoBackground = Colors.grey.shade800.withOpacity(0.5);
   static Color activeTrackColorSwitch = const Color(0xFFFFFFFF);
   static Color inactiveTrackColorSwitch = const Color(0xFFFFFFFF);
   static Color activeColorSwitch = Colors.green;

--- a/lib/ui/views/intro/intro_backup_seed.dart
+++ b/lib/ui/views/intro/intro_backup_seed.dart
@@ -201,6 +201,7 @@ class _IntroBackupSeedState extends ConsumerState<IntroBackupSeedPage> {
                                     bottom: 20,
                                   ),
                                   child: MnemonicDisplay(
+                                    seed: seed!,
                                     wordList: mnemonic!,
                                     explanation: Align(
                                       alignment: Alignment.topLeft,

--- a/lib/ui/views/main/components/recovery_phrase_banner.dart
+++ b/lib/ui/views/main/components/recovery_phrase_banner.dart
@@ -51,7 +51,7 @@ class RecoveryPhraseBanner extends ConsumerWidget {
                       Sheets.showAppHeightNineSheet(
                         context: context,
                         ref: ref,
-                        widget: AppSeedBackupSheet(mnemonic),
+                        widget: AppSeedBackupSheet(mnemonic, seed),
                       );
                     }
                   },

--- a/lib/ui/views/settings/backupseed_sheet.dart
+++ b/lib/ui/views/settings/backupseed_sheet.dart
@@ -20,9 +20,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
 class AppSeedBackupSheet extends ConsumerWidget {
-  const AppSeedBackupSheet(this.mnemonic, {super.key});
+  const AppSeedBackupSheet(this.mnemonic, this.seed, {super.key});
 
   final List<String>? mnemonic;
+  final String seed;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -57,6 +58,7 @@ class AppSeedBackupSheet extends ConsumerWidget {
                                   right: 10,
                                 ),
                                 child: MnemonicDisplay(
+                                  seed: seed,
                                   wordList: mnemonic!,
                                   obscureSeed: true,
                                   explanation: Column(

--- a/lib/ui/views/settings/mnemonic_display.dart
+++ b/lib/ui/views/settings/mnemonic_display.dart
@@ -114,28 +114,30 @@ class _MnemonicDisplayState extends ConsumerState<MnemonicDisplay> {
                       _isExpanded = isExpanded;
                     });
                   },
-                    children: [
-                      ExpansionPanel(
-                        backgroundColor: theme.numMnemonicBackground,
-                        canTapOnHeader: true,
-                        headerBuilder: (BuildContext context, bool isExpanded) {
-                          return ListTile(
-                            title: Text(
-                              AppLocalizations.of(context)!.seedHex,
-                              style: theme.textStyleSize12W600Primary,
-                            ),
-                          );
-                        },
-                        body: Padding(
-                          padding: const EdgeInsets.all(10),
-                          child: SelectableText(
-                            widget.seed,
-                            style: theme.textStyleSize14W600Primary,
+                  children: [
+                    ExpansionPanel(
+                      backgroundColor: ArchethicTheme.numMnemonicBackground,
+                      canTapOnHeader: true,
+                      headerBuilder: (BuildContext context, bool isExpanded) {
+                        return ListTile(
+                          title: Text(
+                            AppLocalizations.of(context)!.seedHex,
+                            style:
+                                ArchethicThemeStyles.textStyleSize12W600Primary,
                           ),
+                        );
+                      },
+                      body: Padding(
+                        padding: const EdgeInsets.all(10),
+                        child: SelectableText(
+                          widget.seed,
+                          style:
+                              ArchethicThemeStyles.textStyleSize14W600Primary,
                         ),
-                        isExpanded: _isExpanded,
                       ),
-                    ],
+                      isExpanded: _isExpanded,
+                    ),
+                  ],
                 ),
               ),
               const SizedBox(

--- a/lib/ui/views/settings/mnemonic_display.dart
+++ b/lib/ui/views/settings/mnemonic_display.dart
@@ -70,7 +70,7 @@ class _MnemonicDisplayState extends ConsumerState<MnemonicDisplay> {
                     padding: const EdgeInsets.all(5),
                     child: Chip(
                       avatar: CircleAvatar(
-                        backgroundColor: ArchethicTheme.numMnemonicBackground,
+                        backgroundColor: ArchethicTheme.seedInfoBackground,
                         child: Text(
                           (entry.key + 1).toString(),
                           style:
@@ -106,38 +106,41 @@ class _MnemonicDisplayState extends ConsumerState<MnemonicDisplay> {
               const SizedBox(
                 height: 30,
               ),
-              ClipRRect(
-                borderRadius: BorderRadius.circular(8),
-                child: ExpansionPanelList(
-                  expansionCallback: (int index, bool isExpanded) {
-                    setState(() {
-                      _isExpanded = isExpanded;
-                    });
-                  },
-                  children: [
-                    ExpansionPanel(
-                      backgroundColor: ArchethicTheme.numMnemonicBackground,
-                      canTapOnHeader: true,
-                      headerBuilder: (BuildContext context, bool isExpanded) {
-                        return ListTile(
-                          title: Text(
-                            AppLocalizations.of(context)!.seedHex,
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 20),
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(8),
+                  child: ExpansionPanelList(
+                    expansionCallback: (int index, bool isExpanded) {
+                      setState(() {
+                        _isExpanded = isExpanded;
+                      });
+                    },
+                    children: [
+                      ExpansionPanel(
+                        backgroundColor: ArchethicTheme.seedInfoBackground,
+                        canTapOnHeader: true,
+                        headerBuilder: (BuildContext context, bool isExpanded) {
+                          return ListTile(
+                            title: Text(
+                              AppLocalizations.of(context)!.seedHex,
+                              style: ArchethicThemeStyles
+                                  .textStyleSize12W400Primary,
+                            ),
+                          );
+                        },
+                        body: Padding(
+                          padding: const EdgeInsets.all(10),
+                          child: SelectableText(
+                            widget.seed,
                             style:
-                                ArchethicThemeStyles.textStyleSize12W600Primary,
+                                ArchethicThemeStyles.textStyleSize12W400Primary,
                           ),
-                        );
-                      },
-                      body: Padding(
-                        padding: const EdgeInsets.all(10),
-                        child: SelectableText(
-                          widget.seed,
-                          style:
-                              ArchethicThemeStyles.textStyleSize14W600Primary,
                         ),
+                        isExpanded: _isExpanded,
                       ),
-                      isExpanded: _isExpanded,
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
               ),
               const SizedBox(

--- a/lib/ui/views/settings/mnemonic_display.dart
+++ b/lib/ui/views/settings/mnemonic_display.dart
@@ -17,6 +17,7 @@ class MnemonicDisplay extends ConsumerStatefulWidget {
   const MnemonicDisplay({
     super.key,
     required this.wordList,
+    required this.seed,
     this.obscureSeed = false,
     required this.explanation,
   });
@@ -24,6 +25,7 @@ class MnemonicDisplay extends ConsumerStatefulWidget {
   final List<String> wordList;
   final bool obscureSeed;
   final Widget explanation;
+  final String seed;
 
   @override
   ConsumerState<MnemonicDisplay> createState() => _MnemonicDisplayState();
@@ -32,6 +34,7 @@ class MnemonicDisplay extends ConsumerStatefulWidget {
 class _MnemonicDisplayState extends ConsumerState<MnemonicDisplay> {
   late bool _seedObscured;
   int curWord = 0;
+  bool _isExpanded = false;
 
   @override
   void initState() {
@@ -100,6 +103,41 @@ class _MnemonicDisplayState extends ConsumerState<MnemonicDisplay> {
                               ArchethicThemeStyles.textStyleSize14W600Primary,
                         ),
                 ),
+              const SizedBox(
+                height: 30,
+              ),
+              ClipRRect(
+                borderRadius: BorderRadius.circular(8),
+                child: ExpansionPanelList(
+                  expansionCallback: (int index, bool isExpanded) {
+                    setState(() {
+                      _isExpanded = isExpanded;
+                    });
+                  },
+                    children: [
+                      ExpansionPanel(
+                        backgroundColor: theme.numMnemonicBackground,
+                        canTapOnHeader: true,
+                        headerBuilder: (BuildContext context, bool isExpanded) {
+                          return ListTile(
+                            title: Text(
+                              AppLocalizations.of(context)!.seedHex,
+                              style: theme.textStyleSize12W600Primary,
+                            ),
+                          );
+                        },
+                        body: Padding(
+                          padding: const EdgeInsets.all(10),
+                          child: SelectableText(
+                            widget.seed,
+                            style: theme.textStyleSize14W600Primary,
+                          ),
+                        ),
+                        isExpanded: _isExpanded,
+                      ),
+                    ],
+                ),
+              ),
               const SizedBox(
                 height: 30,
               ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,14 +17,14 @@ dependencies:
   app_version_update: ^4.0.1
 
   # Archethic dart library for Flutter based on Official Archethic Javascript library for Node and Browser
-  archethic_lib_dart: ^3.3.3
+  archethic_lib_dart: ^3.3.0
   #archethic_lib_dart:
   #  git:
   #    url: https://github.com/archethic-foundation/libdart.git
   #    ref: dev
 
   # Archethic Messaging Dart SDK
-  archethic_messaging_lib_dart: ^0.0.11
+  archethic_messaging_lib_dart: ^0.0.0
   #archethic_messaging_lib_dart:
   #  git:
   #    url: https://github.com/archethic-foundation/messaging_dart_sdk.git


### PR DESCRIPTION
# Description

Display the seed in hexadecimal

Fixes #857 

## Type of change

- New feature (non-breaking change which adds functionality)

## Material used:

Please delete options that are not relevant.
- iOS (Smartphone/Tablet) : iPhone SE / 15 Pro Max

## How Has This Been Tested?

Create a new wallet and go into the intro seed page. You will now be able to get the hexa seed of the current user.
It also the same thing when the user didn't save his passphrase and wants to see it again through the app settings.

### Patrol

Please list here the tests created in Patrol for this pull request.

## Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

## Useful info for the reviewer:
