### PR TITLE
✨ Add focus when DApps interact with Wallet

### DIFF
--- a/lib/ui/views/rpc_command_receiver/add_service/command_handler.dart
+++ b/lib/ui/views/rpc_command_receiver/add_service/command_handler.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:aewallet/application/account/providers.dart';
 import 'package:aewallet/application/connectivity_status.dart';
 import 'package:aewallet/application/settings/settings.dart';
@@ -14,9 +16,11 @@ import 'package:aewallet/ui/views/rpc_command_receiver/add_service/layouts/add_s
 import 'package:aewallet/ui/widgets/components/sheet_util.dart';
 import 'package:aewallet/util/notifications_util.dart';
 import 'package:archethic_lib_dart/archethic_lib_dart.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:window_manager/window_manager.dart';
 
 class AddServiceHandler extends CommandHandler {
   AddServiceHandler({
@@ -78,6 +82,11 @@ class AddServiceHandler extends CommandHandler {
                 type: keychainTransaction.type!,
               ),
             );
+
+            if (!kIsWeb &&
+                (Platform.isLinux || Platform.isMacOS || Platform.isWindows)) {
+              await windowManager.show();
+            }
 
             final result = await Sheets.showAppHeightNineSheet<
                 Result<TransactionConfirmation, TransactionError>>(

--- a/lib/ui/views/rpc_command_receiver/send_transaction/command_handler.dart
+++ b/lib/ui/views/rpc_command_receiver/send_transaction/command_handler.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:aewallet/domain/models/core/result.dart';
 import 'package:aewallet/domain/rpc/command_dispatcher.dart';
 import 'package:aewallet/domain/rpc/commands/command.dart';
@@ -8,9 +10,11 @@ import 'package:aewallet/ui/widgets/components/sheet_util.dart';
 import 'package:aewallet/util/get_it_instance.dart';
 import 'package:aewallet/util/notifications_util.dart';
 import 'package:archethic_lib_dart/archethic_lib_dart.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:window_manager/window_manager.dart';
 
 class SendTransactionHandler extends CommandHandler {
   SendTransactionHandler({
@@ -56,6 +60,11 @@ class SendTransactionHandler extends CommandHandler {
                   authorizedPublicKeys: scAuthorizedKeys,
                 ),
               );
+            }
+
+            if (!kIsWeb &&
+                (Platform.isLinux || Platform.isMacOS || Platform.isWindows)) {
+              await windowManager.show();
             }
 
             _showNotification(

--- a/lib/ui/views/rpc_command_receiver/sign_transactions/command_handler.dart
+++ b/lib/ui/views/rpc_command_receiver/sign_transactions/command_handler.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:aewallet/application/wallet/wallet.dart';
 import 'package:aewallet/domain/models/core/result.dart';
 import 'package:aewallet/domain/rpc/command_dispatcher.dart';
@@ -8,8 +10,10 @@ import 'package:aewallet/ui/themes/archethic_theme.dart';
 import 'package:aewallet/ui/views/rpc_command_receiver/sign_transactions/layouts/sign_transactions_confirmation_form.dart';
 import 'package:aewallet/util/get_it_instance.dart';
 import 'package:archethic_lib_dart/archethic_lib_dart.dart' as archethic;
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:window_manager/window_manager.dart';
 
 const slippage = 1.01;
 
@@ -82,6 +86,11 @@ class SignTransactionsCommandHandler extends CommandHandler {
                   .getTransactionFee(signedTransaction);
               final fees = archethic.fromBigInt(transactionFee.fee) * slippage;
               globalFees = globalFees + fees;
+            }
+
+            if (!kIsWeb &&
+                (Platform.isLinux || Platform.isMacOS || Platform.isWindows)) {
+              await windowManager.show();
             }
 
             final confirmation = await showDialog<bool>(


### PR DESCRIPTION
# Description

Fixes #866 

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

## Material used:

Please delete options that are not relevant.
- iOS (Mac)

## How Has This Been Tested?
With AEWeb and DEX, sign and send tx with the Wallet in background
When Dapps are waiting for an interaction with the Wallet, it appears behind other apps

### Patrol

Please list here the tests created in Patrol for this pull request.

## Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

## Useful info for the reviewer:
