### PR TITLE
fix(pin_screen) : add numpad compatibility

### DIFF
--- a/lib/ui/views/authenticate/pin_screen.dart
+++ b/lib/ui/views/authenticate/pin_screen.dart
@@ -511,9 +511,22 @@ class _PinScreenState extends ConsumerState<PinScreen>
       onKeyEvent: (KeyEvent event) {
         if (event is KeyDownEvent) {
           final logicalKey = event.logicalKey;
-          if (logicalKey.keyLabel.isNotEmpty &&
-              '0123456789'.contains(logicalKey.keyLabel)) {
-            _setCharacter(logicalKey.keyLabel);
+
+          var keyLabel = '';
+          if (logicalKey.keyLabel == '' &&
+              logicalKey.debugName != null &&
+              logicalKey.debugName!.startsWith('Digit')) {
+            keyLabel = logicalKey.debugName!.substring(5);
+          } else if (logicalKey.keyId >= LogicalKeyboardKey.numpad0.keyId &&
+              logicalKey.keyId <= LogicalKeyboardKey.numpad9.keyId) {
+            keyLabel = (logicalKey.keyId - LogicalKeyboardKey.numpad0.keyId)
+                .toString();
+          } else {
+            keyLabel = logicalKey.keyLabel;
+          }
+
+          if (keyLabel.isNotEmpty && '0123456789'.contains(keyLabel)) {
+            _setCharacter(keyLabel);
             if (allExpectedCharactersEntered) {
               // Mild delay so they can actually see the last dot get filled
               Future<void>.delayed(


### PR DESCRIPTION
# Description

This pull request adds numpad compatibility to the pin screen. Previously, only the numeric keys on the main keyboard were supported for entering the pin. With this change, users can now also use the numeric keys on the numpad to enter their pin.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Material used:

- Windows

## Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules