### PR TITLE
Lock screen dismissed by "back button"

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-flutter 3.19.5-stable
+flutter 3.19.6-stable
 nodejs 21.2.0

--- a/lib/ui/views/authenticate/auto_lock_guard.dart
+++ b/lib/ui/views/authenticate/auto_lock_guard.dart
@@ -324,7 +324,7 @@ class _LockMaskState extends State<_LockMask> {
   @override
   Widget build(BuildContext context) {
     return PopScope(
-      onPopInvoked: (didPop) async => false,
+      canPop: false,
       child: Stack(
         alignment: Alignment.center,
         children: [

--- a/lib/ui/views/authenticate/lock_screen.dart
+++ b/lib/ui/views/authenticate/lock_screen.dart
@@ -41,10 +41,13 @@ class AppLockScreen extends ConsumerWidget implements SheetSkeletonInterface {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return SheetSkeleton(
-      appBar: getAppBar(context, ref),
-      floatingActionButton: getFloatingActionButton(context, ref),
-      sheetContent: getSheetContent(context, ref),
+    return PopScope(
+      canPop: false,
+      child: SheetSkeleton(
+        appBar: getAppBar(context, ref),
+        floatingActionButton: getFloatingActionButton(context, ref),
+        sheetContent: getSheetContent(context, ref),
+      ),
     );
   }
 
@@ -102,15 +105,12 @@ class AppLockScreen extends ConsumerWidget implements SheetSkeletonInterface {
   Widget getSheetContent(BuildContext context, WidgetRef ref) {
     final localizations = AppLocalizations.of(context)!;
 
-    return PopScope(
-      onPopInvoked: (didPop) async => false,
-      child: SizedBox(
-        width: MediaQuery.of(context).size.width,
-        child: Text(
-          localizations.tooManyFailedAttempts,
-          style: ArchethicThemeStyles.textStyleSize14W600Primary,
-          textAlign: TextAlign.center,
-        ),
+    return SizedBox(
+      width: MediaQuery.of(context).size.width,
+      child: Text(
+        localizations.tooManyFailedAttempts,
+        style: ArchethicThemeStyles.textStyleSize14W600Primary,
+        textAlign: TextAlign.center,
       ),
     );
   }

--- a/lib/ui/views/authenticate/password_screen.dart
+++ b/lib/ui/views/authenticate/password_screen.dart
@@ -88,7 +88,7 @@ class _PasswordScreenState extends ConsumerState<PasswordScreen>
   @override
   Widget build(BuildContext context) {
     return PopScope(
-      onPopInvoked: (didPop) async => widget.canNavigateBack,
+      canPop: widget.canNavigateBack,
       child: SheetSkeleton(
         appBar: getAppBar(context, ref),
         floatingActionButton: getFloatingActionButton(context, ref),

--- a/lib/ui/views/authenticate/yubikey_screen.dart
+++ b/lib/ui/views/authenticate/yubikey_screen.dart
@@ -163,7 +163,7 @@ class _YubikeyScreenState extends ConsumerState<YubikeyScreen>
     final preferences = ref.watch(SettingsProviders.settings);
 
     return PopScope(
-      onPopInvoked: (didPop) async => widget.canNavigateBack,
+      canPop: widget.canNavigateBack,
       child: Column(
         children: <Widget>[
           if (isNFCAvailable)


### PR DESCRIPTION

# Description

Uses `PopScope.canPop` to prevent back navigation. 

Fixes #949
