### PR TITLE
Fixes RPC Confirmation popups are not hidden by LockScreen #1011

### DIFF
--- a/lib/router/router.dart
+++ b/lib/router/router.dart
@@ -161,9 +161,9 @@ class RoutesPath {
             ),
           ),
         ),
-        RPCCommandReceiverRoute(
+        AutoLockGuardRoute(
           routes: [
-            AutoLockGuardRoute(
+            RPCCommandReceiverRoute(
               routes: _authenticatedRoutes,
             ),
           ],


### PR DESCRIPTION
# Description

Fixes #1011

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Material used:

- iOS (Mac)

## How Has This Been Tested?

With aeSwap
Try a swap with wallet 
- opened and not locked
- force locked
- locked after a duration
The validation screen appears after authentification for the 2 last cases
Tests ok

## Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

## Useful info for the reviewer:
