### PR TITLE
🐛 RPCSubscribeCurrentAccountCommandHandler doesn't send the good name

### DIFF
--- a/lib/infrastructure/rpc/sub_current_account/command_handler.dart
+++ b/lib/infrastructure/rpc/sub_current_account/command_handler.dart
@@ -21,6 +21,23 @@ class RPCSubscribeCurrentAccountCommandHandler extends RPCSubscriptionHandler<
           genesisAddress: '',
           name: '',
         );
-    return modelNotNull.toJson();
+    return {
+      'name': _getShortName(modelNotNull.name),
+      'genesisAddress': modelNotNull.genesisAddress,
+    };
+  }
+
+  String _getShortName(String name) {
+    var result = name;
+    if (name.startsWith('archethic-wallet-')) {
+      result = result.replaceFirst('archethic-wallet-', '');
+    }
+    if (name.startsWith('aeweb-')) {
+      result = result.replaceFirst('aeweb-', '');
+    }
+
+    return Uri.decodeFull(
+      result,
+    );
   }
 }


### PR DESCRIPTION
# Description

Fixes #1016 

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Material used:

Please delete options that are not relevant.
- iOS (Mac)

## How Has This Been Tested?
Use service name with special character and use Dapps
Before this fix, Dapps receive "Service not found" error

## Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

## Useful info for the reviewer:
