### PR TITLE
Error when user goes to wallets menu while the refresh process is in progress

### DIFF
--- a/lib/application/account/providers.dart
+++ b/lib/application/account/providers.dart
@@ -4,6 +4,7 @@ import 'dart:async';
 
 import 'package:aewallet/application/connectivity_status.dart';
 import 'package:aewallet/application/nft/nft.dart';
+import 'package:aewallet/application/refresh_in_progress.dart';
 import 'package:aewallet/application/session/session.dart';
 import 'package:aewallet/domain/repositories/account.dart';
 import 'package:aewallet/infrastructure/repositories/local_account.dart';

--- a/lib/application/account/selected_account_notifier.dart
+++ b/lib/application/account/selected_account_notifier.dart
@@ -36,8 +36,10 @@ class _SelectedAccountNotifier extends AutoDisposeAsyncNotifier<Account?> {
     final accountNotifier = ref.read(
       AccountProviders.account(accountName).notifier,
     );
-
-    return doRefresh(accountNotifier);
+    ref.read(refreshInProgressProviders.notifier).setRefreshInProgress(true);
+    await doRefresh(accountNotifier);
+    ref.read(refreshInProgressProviders.notifier).setRefreshInProgress(false);
+    return;
   }
 
   Future<void> refreshRecentTransactions() => _refresh(

--- a/lib/application/migrations/migration_manager.g.dart
+++ b/lib/application/migrations/migration_manager.g.dart
@@ -6,7 +6,7 @@ part of 'migration_manager.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$migrationsHash() => r'6a934fe7ff042840d5038a6c23db06ebe60145fe';
+String _$migrationsHash() => r'ab0c4b15c096a63d251c0a8b1d30cb3fec55f3e2';
 
 /// See also [_migrations].
 @ProviderFor(_migrations)

--- a/lib/ui/views/main/components/menu_widget_wallet.dart
+++ b/lib/ui/views/main/components/menu_widget_wallet.dart
@@ -152,10 +152,6 @@ class MenuWidgetWallet extends ConsumerWidget {
                 text: localizations.refresh,
                 icon: Symbols.refresh,
                 onTap: () async {
-                  ref
-                      .read(refreshInProgressProviders.notifier)
-                      .setRefreshInProgress(true);
-
                   sl.get<HapticUtil>().feedback(
                         FeedbackType.light,
                         preferences.activeVibrations,
@@ -170,17 +166,17 @@ class MenuWidgetWallet extends ConsumerWidget {
                   await ref
                       .read(AccountProviders.selectedAccount.notifier)
                       .refreshRecentTransactions();
-                  ref
-                    ..invalidate(ContactProviders.fetchContacts)
-                    ..invalidate(MarketPriceProviders.currencyMarketPrice);
-                  await ref
-                      .read(
-                        VerifiedTokensProviders.verifiedTokens.notifier,
-                      )
-                      .init();
-                  ref
-                      .read(refreshInProgressProviders.notifier)
-                      .setRefreshInProgress(false);
+
+                  if (context.mounted) {
+                    ref
+                      ..invalidate(ContactProviders.fetchContacts)
+                      ..invalidate(MarketPriceProviders.currencyMarketPrice);
+                    await ref
+                        .read(
+                          VerifiedTokensProviders.verifiedTokens.notifier,
+                        )
+                        .init();
+                  }
                 },
               )
                   .animate()


### PR DESCRIPTION
# Description

Fixes #1007

I moved the management of the refresh in progress indicator too because if an error occurs, the refresh indicator doesn't stop. And now, when user pulls to refresh, the button refresh is associated to the pull to refresh

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Material used:

Please delete options that are not relevant.
- iOS (Mac)

## How Has This Been Tested?

- Click on menu while a refreshing process and no error in the log console
- Pull to refresh and check the button Refresh. It should have a circular indicator while the refreshing process


## Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

## Useful info for the reviewer:
