### PR TITLE
fix: :bug: Prevent scroll detection when there a no user input.

### DIFF
--- a/lib/ui/views/authenticate/auto_lock_guard.dart
+++ b/lib/ui/views/authenticate/auto_lock_guard.dart
@@ -72,13 +72,11 @@ class _AutoLockGuardState extends ConsumerState<AutoLockGuard>
 
     return InputListener(
       onInput: () {
-        WidgetsBinding.instance.addPostFrameCallback((_) {
-          ref
-              .read(
-                AuthenticationProviders.authenticationGuard.notifier,
-              )
-              .scheduleAutolock();
-        });
+        ref
+            .read(
+              AuthenticationProviders.authenticationGuard.notifier,
+            )
+            .scheduleAutolock();
       },
       child: Stack(
         children: [
@@ -170,13 +168,7 @@ class InputListener extends StatelessWidget {
         child: Listener(
           onPointerDown: (_) => onInput(),
           onPointerMove: (_) => onInput(),
-          child: NotificationListener<ScrollNotification>(
-            onNotification: (ScrollNotification notification) {
-              onInput();
-              return true;
-            },
-            child: child,
-          ),
+          child: child,
         ),
       );
 }


### PR DESCRIPTION
# Description

when switching account, on the end of the process, application triggers a lot of scroll input detection without any user interaction.

This is a fix attempt. Will have to see if there are problematic cases .