### PR TITLE
Add remove wallet feature in lock screen

### DIFF
--- a/lib/domain/usecases/authentication/authentication.dart
+++ b/lib/domain/usecases/authentication/authentication.dart
@@ -17,7 +17,7 @@ mixin AuthenticationWithLock {
   static int get maxFailedAttempts => 5;
 
   Duration lockDuration(int attempts) {
-    if (attempts == 20) {
+    if (attempts >= 20) {
       return const Duration(hours: 24);
     }
 

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -53,6 +53,7 @@
     "languageDefaultSettings": "System language",
     "removeWallet": "Remove Wallet from this device",
     "removeWalletLight": "Remove wallet",
+    "removeWalletBtn": "Remove Wallet",
     "removeWalletDescription": "You can find it at any time with your secret phrase",
     "resyncWallet": "Resynchronize Wallet",
     "resyncWalletAreYouSure": "Are you sure you want to clear your cache and reload the information from the blockchain?\n\nThis action takes a few seconds and is safe because it only reloads your recent transactions.",

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -53,6 +53,7 @@
     "languageDefaultSettings": "Langue du système",
     "removeWallet": "Supprimer le wallet de cet appareil",
     "removeWalletLight": "Supp. le wallet",
+    "removeWalletBtn": "Supprimer le wallet",
     "resyncWallet": "Resynchroniser le wallet",
     "resyncWalletAreYouSure": "Êtes-vous sûr(e) de vouloir vider votre cache et recharger les informations à partir de la blockchain ?\n\nCette action requiert quelques secondes et est sans risque car elle recharge uniquement vos transactions récentes.",
     "resyncWalletDescription": "Vider le cache et recharger les informations de la blockchain",

--- a/lib/ui/views/authenticate/auto_lock_guard.dart
+++ b/lib/ui/views/authenticate/auto_lock_guard.dart
@@ -4,15 +4,21 @@ import 'package:aewallet/application/authentication/authentication.dart';
 import 'package:aewallet/ui/themes/archethic_theme.dart';
 import 'package:aewallet/ui/themes/styles.dart';
 import 'package:aewallet/ui/util/dimens.dart';
+import 'package:aewallet/ui/views/authenticate/auth_factory.dart';
 import 'package:aewallet/ui/views/authenticate/components/lock_overlay.mixin.dart';
+import 'package:aewallet/ui/views/authenticate/logging_out.dart';
 import 'package:aewallet/ui/views/main/components/sheet_appbar.dart';
+import 'package:aewallet/ui/widgets/components/app_button.dart';
 import 'package:aewallet/ui/widgets/components/app_button_tiny.dart';
 import 'package:aewallet/ui/widgets/components/sheet_skeleton.dart';
 import 'package:aewallet/ui/widgets/components/sheet_skeleton_interface.dart';
+import 'package:archethic_dapp_framework_flutter/archethic_dapp_framework_flutter.dart'
+    as aedappfm;
 import 'package:async/async.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:logging/logging.dart';
 
 part 'components/lock_mask_screen.dart';

--- a/lib/ui/views/authenticate/auto_lock_guard.dart
+++ b/lib/ui/views/authenticate/auto_lock_guard.dart
@@ -4,7 +4,6 @@ import 'package:aewallet/application/authentication/authentication.dart';
 import 'package:aewallet/ui/themes/archethic_theme.dart';
 import 'package:aewallet/ui/themes/styles.dart';
 import 'package:aewallet/ui/util/dimens.dart';
-import 'package:aewallet/ui/views/authenticate/auth_factory.dart';
 import 'package:aewallet/ui/views/authenticate/components/lock_overlay.mixin.dart';
 import 'package:aewallet/ui/views/authenticate/logging_out.dart';
 import 'package:aewallet/ui/views/main/components/sheet_appbar.dart';

--- a/lib/ui/views/authenticate/countdown_lock_screen.dart
+++ b/lib/ui/views/authenticate/countdown_lock_screen.dart
@@ -80,19 +80,51 @@ class _CountdownLockScreen extends ConsumerWidget
             )
             .valueOrNull ??
         '';
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: <Widget>[
-        AppButtonTiny(
-          AppButtonTinyType.primary,
-          isLocked ? countDownString : localizations.unlock,
-          Dimens.buttonBottomDimens,
-          key: const Key('unlock'),
-          onPressed: () {
-            if (isLocked) return;
-            CountdownLockOverlay.instance().hide();
-          },
-          disabled: isLocked,
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            AppButtonTiny(
+              AppButtonTinyType.primary,
+              isLocked ? countDownString : localizations.unlock,
+              Dimens.buttonTopDimens,
+              key: const Key('unlock'),
+              onPressed: () {
+                if (isLocked) return;
+                CountdownLockOverlay.instance().hide();
+              },
+              disabled: isLocked,
+            ),
+          ],
+        ),
+        Container(
+          height: 50,
+          margin: Dimens.buttonBottomDimens.edgeInsetsDirectional,
+          child: FilledButton(
+            onPressed: () {
+              RemoveWalletDialogOverlay.showOverlay(
+                context,
+                ref,
+              );
+            },
+            style: FilledButton.styleFrom(
+              backgroundColor: Colors.red,
+              foregroundColor:
+                  ArchethicThemeStyles.textStyleSize16W400MainButtonLabel.color,
+            ),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text(
+                  AppLocalizations.of(context)!.removeWalletBtn,
+                  style:
+                      ArchethicThemeStyles.textStyleSize16W400MainButtonLabel,
+                ),
+              ],
+            ),
+          ),
         ),
       ],
     );
@@ -121,5 +153,154 @@ class _CountdownLockScreen extends ConsumerWidget
         textAlign: TextAlign.center,
       ),
     );
+  }
+}
+
+class RemoveWalletDialogOverlay {
+  static void showOverlay(
+    BuildContext context,
+    WidgetRef ref,
+  ) {
+    final localizations = AppLocalizations.of(context)!;
+
+    OverlayEntry? overlayEntry;
+
+    overlayEntry = OverlayEntry(
+      builder: (BuildContext overlayContext) {
+        return Positioned(
+          top: 0,
+          bottom: 0,
+          left: 0,
+          right: 0,
+          child: Material(
+            color: Colors.black.withOpacity(0.8),
+            child: SizedBox(
+              width: MediaQuery.of(context).size.width,
+              child: Center(
+                child: aedappfm.PopupTemplate(
+                  displayCloseButton: false,
+                  popupTitle: localizations.warning,
+                  popupContent: Column(
+                    children: [
+                      Text(
+                        localizations.removeWalletDetail,
+                        style: ArchethicThemeStyles.textStyleSize12W100Primary,
+                      ),
+                      const SizedBox(
+                        height: 20,
+                      ),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          AppButton(
+                            key: const Key('cancelButton'),
+                            labelBtn: AppLocalizations.of(
+                              context,
+                            )!
+                                .no,
+                            onPressed: () {
+                              overlayEntry?.remove();
+                            },
+                          ),
+                          AppButton(
+                            key: const Key('yesButton'),
+                            labelBtn: localizations.yes,
+                            onPressed: () async {
+                              overlayEntry?.remove();
+                              Overlay.of(context).insert(
+                                _createConfirmOverlay(
+                                  context,
+                                  ref,
+                                ),
+                              );
+                            },
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+
+    Overlay.of(context).insert(overlayEntry);
+  }
+
+  static OverlayEntry _createConfirmOverlay(
+    BuildContext context,
+    WidgetRef ref,
+  ) {
+    final localizations = AppLocalizations.of(context)!;
+
+    OverlayEntry? overlayEntry;
+
+    // ignore: join_return_with_assignment
+    overlayEntry = OverlayEntry(
+      builder: (BuildContext overlayContext) {
+        return Positioned(
+          top: 0,
+          bottom: 0,
+          left: 0,
+          right: 0,
+          child: Material(
+            color: Colors.black.withOpacity(0.8),
+            child: SizedBox(
+              width: MediaQuery.of(context).size.width,
+              child: Center(
+                child: aedappfm.PopupTemplate(
+                  displayCloseButton: false,
+                  popupTitle: localizations.areYouSure,
+                  popupContent: Column(
+                    children: [
+                      Text(
+                        localizations.removeWalletReassurance,
+                        style: ArchethicThemeStyles.textStyleSize12W100Primary,
+                      ),
+                      const SizedBox(
+                        height: 20,
+                      ),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          AppButton(
+                            key: const Key('cancelButton'),
+                            labelBtn: AppLocalizations.of(
+                              context,
+                            )!
+                                .no,
+                            onPressed: () {
+                              overlayEntry?.remove();
+                            },
+                          ),
+                          AppButton(
+                            key: const Key('yesButton'),
+                            labelBtn: AppLocalizations.of(
+                              context,
+                            )!
+                                .yes,
+                            onPressed: () async {
+                              overlayEntry?.remove();
+
+                              CountdownLockOverlay.instance().hide();
+                              context.go(LoggingOutScreen.routerPage);
+                            },
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+
+    return overlayEntry;
   }
 }


### PR DESCRIPTION
# Description

Fixes #950

## Type of change
- New feature (non-breaking change which adds functionality)

## Material used:

Please delete options that are not relevant.
- iOS (Smartphone/Tablet)

## How Has This Been Tested?

- Lock your app with wrong access code (pin or password)
- Click on Remove Wallet button, next "yes", "yes" 
You come back to welcome page with Vault resetted

## Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

## Useful info for the reviewer:
