### PR TITLE
Fix: Migration 541 reads wrong key in _migrateNonWehAuthentSecureKey

### DIFF
--- a/lib/application/migrations/541.dart
+++ b/lib/application/migrations/541.dart
@@ -26,7 +26,7 @@ final migration_541 = LocalDataMigration(
     }
 
     Future<void> _migrateNonWehAuthentSecureKey() async {
-      final key = await secureStorage.read(key: kVaultSecureKey);
+      final key = await secureStorage.read(key: kNonWebAuthenticationSecureKey);
       if (key == null) {
         logger.info('No NonWebAuthent secure key to migrate');
         return;


### PR DESCRIPTION
## Bug Description

The `_migrateNonWehAuthentSecureKey()` function in migration 541 was incorrectly reading from `kVaultSecureKey` instead of `kNonWebAuthenticationSecureKey`. This caused it to:

1. Read the same key as `_migrateVaultSecureKey()`
2. Potentially overwrite the wrong destination
3. Fail to migrate the intended NonWebAuthent secure key data

## Fix

Changed the source key in `_migrateNonWehAuthentSecureKey()` from `kVaultSecureKey` to `kNonWebAuthenticationSecureKey` so it correctly reads the NonWebAuthent secure key for migration.

## Files Changed
- `lib/application/migrations/541.dart` - Fixed line 31 to read from correct source key

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.